### PR TITLE
Improve add_task and typings

### DIFF
--- a/asyncz/exceptions.py
+++ b/asyncz/exceptions.py
@@ -55,7 +55,7 @@ class SchedulerLookupError(BaseLookupError):
 class TaskLookupError(BaseLookupError):
     detail = "No task with the id {task_id} has been found."
 
-    def __init__(self, task_id: str) -> None:
+    def __init__(self, task_id: Optional[str]) -> None:
         detail = self.detail.format(task_id=task_id)
         super().__init__(detail=detail)
 
@@ -71,7 +71,7 @@ class ConflictError(KeyError):
 class ConflictIdError(KeyError):
     detail = "Task identifier ({task_id}) conflicts with an existing task."
 
-    def __init__(self, task_id: str) -> None:
+    def __init__(self, task_id: Optional[str]) -> None:
         detail = self.detail.format(task_id=task_id)
         super().__init__(detail)
 

--- a/asyncz/executors/asyncio.py
+++ b/asyncz/executors/asyncio.py
@@ -34,14 +34,17 @@ class AsyncIOExecutor(BaseExecutor):
         self.pending_futures.clear()
 
     def do_send_task(self, task: "TaskType", run_times: List[datetime]) -> None:
+        task_id = task.id
+        assert task_id is not None, "Cannot send decorator type task"
+
         def callback(fn: Any) -> None:
             self.pending_futures.discard(fn)
             try:
                 events = fn.result()
             except BaseException:
-                self.run_task_error(task.id)
+                self.run_task_error(task_id)
             else:
-                self.run_task_success(task.id, events)
+                self.run_task_success(task_id, events)
 
         if iscoroutinefunction_partial(task.fn):
             if run_coroutine_task is not None:

--- a/asyncz/executors/asyncio.py
+++ b/asyncz/executors/asyncio.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, List, Set
 
-from asyncz.exceptions import AsynczException
 from asyncz.executors.base import BaseExecutor, run_coroutine_task, run_task
 from asyncz.utils import iscoroutinefunction_partial
 
@@ -47,13 +46,8 @@ class AsyncIOExecutor(BaseExecutor):
                 self.run_task_success(task_id, events)
 
         if iscoroutinefunction_partial(task.fn):
-            if run_coroutine_task is not None:
-                coroutine = run_coroutine_task(task, task.store_alias, run_times, self.logger)  # type: ignore
-                fn = self.event_loop.create_task(coroutine)
-            else:
-                raise AsynczException(
-                    detail="Executing coroutine based tasks is not supported with Trollius."
-                )
+            coroutine = run_coroutine_task(task, task.store_alias, run_times, self.logger)  # type: ignore
+            fn = self.event_loop.create_task(coroutine)
         else:
             fn = self.event_loop.run_in_executor(
                 None, run_task, task, task.store_alias, run_times, self.logger

--- a/asyncz/executors/base.py
+++ b/asyncz/executors/base.py
@@ -111,9 +111,10 @@ def run_task(
 
     events = []
     for run_time in run_times:
-        if getattr(task, "mistrigger_grace_time", None) is not None:
+        mistrigger_grace_time = task.mistrigger_grace_time
+        if mistrigger_grace_time is not None:
             difference = datetime.now(tz.utc) - run_time
-            grace_time = timedelta(seconds=task.mistrigger_grace_time)
+            grace_time = timedelta(seconds=mistrigger_grace_time)
             if difference > grace_time:
                 events.append(
                     TaskExecutionEvent(
@@ -175,9 +176,10 @@ async def run_coroutine_task(
 
     events = []
     for run_time in run_times:
-        if getattr(task, "mistrigger_grace_time", None) is not None:
+        mistrigger_grace_time = task.mistrigger_grace_time
+        if mistrigger_grace_time is not None:
             difference = datetime.now(tz.utc) - run_time
-            grace_time = timedelta(seconds=task.mistrigger_grace_time)
+            grace_time = timedelta(seconds=mistrigger_grace_time)
             if difference > grace_time:
                 events.append(
                     TaskExecutionEvent(

--- a/asyncz/executors/base.py
+++ b/asyncz/executors/base.py
@@ -62,6 +62,7 @@ class BaseExecutor(BaseStateExtra, ExecutorType):
             run_times: A list of datetimes specifying when the task should have been run.
         """
         assert self.lock is not None, "This executor has not been started yet."
+        assert task.id is not None, "The task is in decorator mode."
         with self.lock:
             if self.instances[task.id] >= task.max_instances:
                 raise MaximumInstancesError(task.id, task.max_instances)

--- a/asyncz/executors/debug.py
+++ b/asyncz/executors/debug.py
@@ -18,6 +18,7 @@ class DebugExecutor(BaseExecutor):
         task: "TaskType",
         run_times: List[datetime],
     ) -> None:
+        assert task.id is not None, "Cannot send decorator type task"
         try:
             events = run_task(task, task.store_alias, run_times, self.logger)  # type: ignore
         except Exception:

--- a/asyncz/executors/pool.py
+++ b/asyncz/executors/pool.py
@@ -21,6 +21,9 @@ class BasePoolExecutor(BaseExecutor):
         self.pool = pool
 
     def do_send_task(self, task: "TaskType", run_times: List[datetime]) -> Any:
+        task_id = task.id
+        assert task_id is not None, "Cannot send decorator type task"
+
         def callback(fn: Any) -> None:
             exc, _ = (
                 fn.exception_info()
@@ -28,9 +31,9 @@ class BasePoolExecutor(BaseExecutor):
                 else (fn.exception(), getattr(fn.exception(), "__traceback__", None))
             )
             if exc:
-                self.run_task_error(task.id)
+                self.run_task_error(task_id)
             else:
-                self.run_task_success(task.id, fn.result())
+                self.run_task_success(task_id, fn.result())
 
         try:
             fn = self.pool.submit(run_task, task, task.store_alias, run_times)

--- a/asyncz/schedulers/asgi.py
+++ b/asyncz/schedulers/asgi.py
@@ -28,6 +28,7 @@ class ASGIHelper:
     app: ASGIApp
     scheduler: BaseScheduler
     handle_lifespan: bool = False
+    wait: bool = True
 
     async def __call__(
         self,
@@ -48,7 +49,7 @@ class ASGIHelper:
                         raise MuteInteruptException from None
                 elif message["type"] == "lifespan.shutdown":
                     try:
-                        self.scheduler.shutdown()
+                        self.scheduler.shutdown(self.wait)
                     except Exception as exc:
                         await send({"type": "lifespan.shutdown.failed", "msg": str(exc)})
                         raise MuteInteruptException from None

--- a/asyncz/schedulers/base.py
+++ b/asyncz/schedulers/base.py
@@ -540,7 +540,7 @@ class BaseScheduler(SchedulerType):
 
     def update_task(self, task_id: str, store: Optional[str] = None, **updates: Any) -> "TaskType":
         """
-        Modifies the propertues of a single task.
+        Modifies the properties of a single task.
 
         Modifications are passed to this method as extra keyword arguments.
 

--- a/asyncz/schedulers/base.py
+++ b/asyncz/schedulers/base.py
@@ -353,7 +353,7 @@ class BaseScheduler(SchedulerType):
 
         self.dispatch_event(SchedulerEvent(code=STORE_ADDED, alias=alias))
 
-        if self.state == SchedulerState.STATE_STOPPED:
+        if self.state == SchedulerState.STATE_RUNNING:
             self.wakeup()
 
     def remove_store(self, alias: str, shutdown: bool = True) -> None:

--- a/asyncz/schedulers/base.py
+++ b/asyncz/schedulers/base.py
@@ -453,6 +453,7 @@ class BaseScheduler(SchedulerType):
         """
         if isinstance(fn_or_task, TaskType):
             assert fn_or_task.id is not None, "Cannot submit a decorator type task."
+            fn_or_task.scheduler = self
             with self.store_lock:
                 if self.state == SchedulerState.STATE_STOPPED:
                     self.pending_tasks.append(
@@ -467,6 +468,7 @@ class BaseScheduler(SchedulerType):
                     )
             return fn_or_task
         task_struct = {
+            "scheduler": self,
             "trigger": self.create_trigger(trigger, trigger_args),
             "executor": executor,
             "fn": fn_or_task,
@@ -483,7 +485,7 @@ class BaseScheduler(SchedulerType):
         task_kwargs: Dict[str, Any] = {
             key: value for key, value in task_struct.items() if value is not undefined
         }
-        task = Task(self, **task_kwargs)
+        task = Task(**task_kwargs)
         if task.fn is not None:
             return self.add_task(task, replace_existing=replace_existing)
         return task

--- a/asyncz/schedulers/datastructures.py
+++ b/asyncz/schedulers/datastructures.py
@@ -1,12 +1,9 @@
-from typing import Optional, Union
+from typing import Optional  # noqa: F401
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel
 
-from asyncz.typing import UndefinedType
+from asyncz.tasks.types import TaskDefaultsType
 
 
-class TaskDefaultStruct(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-    mistrigger_grace_time: Optional[Union[int, "UndefinedType"]]
-    coalesce: Optional[Union[bool, "UndefinedType"]]
-    max_instances: Optional[Union[int, "UndefinedType"]]
+class TaskDefaultStruct(BaseModel, TaskDefaultsType):
+    pass

--- a/asyncz/schedulers/types.py
+++ b/asyncz/schedulers/types.py
@@ -178,7 +178,9 @@ class SchedulerType(ABC):
         """
 
     @abstractmethod
-    def update_task(self, task_id: str, store: Optional[str] = None, **updates: Any) -> TaskType:
+    def update_task(
+        self, task_id: Union[TaskType, str], store: Optional[str] = None, **updates: Any
+    ) -> TaskType:
         """
         Modifies the properties of a single task.
 
@@ -192,7 +194,7 @@ class SchedulerType(ABC):
     @abstractmethod
     def reschedule_task(
         self,
-        task_id: str,
+        task_id: Union[TaskType, str],
         store: Optional[str] = None,
         trigger: Optional[Union[str, TriggerType]] = None,
         **trigger_args: Any,
@@ -209,7 +211,7 @@ class SchedulerType(ABC):
         """
 
     @abstractmethod
-    def pause_task(self, task_id: str, store: Optional[str] = None) -> TaskType:
+    def pause_task(self, task_id: Union[TaskType, str], store: Optional[str] = None) -> TaskType:
         """
         Causes the given task not to be executed until it is explicitly resumed.
 
@@ -219,7 +221,9 @@ class SchedulerType(ABC):
         """
 
     @abstractmethod
-    def resume_task(self, task_id: str, store: Optional[str] = None) -> Union[TaskType, None]:
+    def resume_task(
+        self, task_id: Union[TaskType, str], store: Optional[str] = None
+    ) -> Union[TaskType, None]:
         """
         Resumes the schedule of the given task, or removes the task if its schedule is finished.
 
@@ -252,7 +256,9 @@ class SchedulerType(ABC):
         """
 
     @abstractmethod
-    def delete_task(self, task_id: str, store: Optional[str] = None) -> None:
+    def delete_task(
+        self, task_id: Union[TaskType, str, None], store: Optional[str] = None
+    ) -> None:
         """
         Removes a task, preventing it from being run anymore.
 

--- a/asyncz/schedulers/types.py
+++ b/asyncz/schedulers/types.py
@@ -124,16 +124,16 @@ class SchedulerType(ABC):
     @abstractmethod
     def add_task(
         self,
-        fn: Optional[Callable[..., Any]],
+        fn_or_task: Optional[Union[Callable[..., Any], TaskType]] = None,
         trigger: Optional[Union[TriggerType, str]] = None,
         args: Optional[Any] = None,
         kwargs: Optional[Any] = None,
         id: Optional[str] = None,
         name: Optional[str] = None,
-        mistrigger_grace_time: Union[int, UndefinedType] = undefined,
+        mistrigger_grace_time: Union[int, UndefinedType, None] = undefined,
         coalesce: Union[bool, UndefinedType] = undefined,
-        max_instances: Union[int, UndefinedType] = undefined,
-        next_run_time: Union[datetime, str, UndefinedType] = undefined,
+        max_instances: Union[int, UndefinedType, None] = undefined,
+        next_run_time: Union[datetime, str, UndefinedType, None] = undefined,
         store: str = "default",
         executor: str = "default",
         replace_existing: bool = False,
@@ -175,43 +175,6 @@ class SchedulerType(ABC):
             executor: Alias of the executor to run the task with.
             replace_existing: True to replace an existing task with the same id
                               (but retain the number of runs from the existing one).
-        """
-
-    @abstractmethod
-    def scheduled_task(
-        self,
-        trigger: Optional[Union[TriggerType, str]] = None,
-        args: Optional[Any] = None,
-        kwargs: Optional[Any] = None,
-        id: Optional[str] = None,
-        name: Optional[str] = None,
-        mistrigger_grace_time: Union[int, UndefinedType] = undefined,
-        coalesce: Union[bool, UndefinedType] = undefined,
-        max_instances: Union[int, UndefinedType] = undefined,
-        next_run_time: Union[datetime, str, UndefinedType] = undefined,
-        store: str = "default",
-        executor: str = "default",
-        **trigger_args: Any,
-    ) -> Callable[..., Any]:
-        """
-        Functionality that can be used as a decorator for any function to schedule a task
-        with a difference that replace_existing is always True.
-
-        Args:
-            trigger: Trigger that determines when fn is called.
-            args: List of positional arguments to call fn with.
-            kwargs: Dict of keyword arguments to call fn with.
-            id: Explicit identifier for the task (for modifying it later).
-            name: Textual description of the task.
-            mistriger_grace_time: Seconds after the designated runtime that the task is still
-                allowed to be run (or None to allow the task to run no matter how late it is).
-            coalesce: Run once instead of many times if the scheduler determines that the
-                task should be run more than once in succession.
-            max_instances: Maximum number of concurrently running instances allowed for this task.
-            next_run_time: When to first run the task, regardless of the trigger (pass
-                None to add the task as paused).
-            store: Alias of the task store to store the task in.
-            executor: Alias of the executor to run the task with.
         """
 
     @abstractmethod

--- a/asyncz/schedulers/types.py
+++ b/asyncz/schedulers/types.py
@@ -217,7 +217,7 @@ class SchedulerType(ABC):
     @abstractmethod
     def update_task(self, task_id: str, store: Optional[str] = None, **updates: Any) -> TaskType:
         """
-        Modifies the propertues of a single task.
+        Modifies the properties of a single task.
 
         Modifications are passed to this method as extra keyword arguments.
 
@@ -301,7 +301,7 @@ class SchedulerType(ABC):
     @abstractmethod
     def remove_all_tasks(self, store: Optional[str]) -> None:
         """
-        Removes all tasks from the specified task store, or all task stores if none is given.
+        Removes all tasks from the specified task store, or all task stores if None is given.
         """
 
     @abstractmethod

--- a/asyncz/stores/memory.py
+++ b/asyncz/stores/memory.py
@@ -40,6 +40,7 @@ class MemoryStore(BaseStore):
         return [task[0] for task in self.tasks]
 
     def add_task(self, task: "TaskType") -> None:
+        assert task.id is not None, "The task is in decorator mode."
         if task.id in self.tasks_index:
             raise ConflictIdError(task.id)
 
@@ -50,11 +51,12 @@ class MemoryStore(BaseStore):
         self.tasks_index[task.id] = (task, timestamp)
 
     def update_task(self, task: "TaskType") -> None:
+        assert task.id is not None, "The task is in decorator mode."
         old_task, old_timestamp = self.tasks_index.get(task.id, (None, None))
         if old_task is None:
             raise TaskLookupError(task.id)
 
-        old_index = self.get_task_index(old_timestamp, old_task.id)
+        old_index = self.get_task_index(old_timestamp, old_task.id)  # type: ignore
         new_timestamp = datetime_to_utc_timestamp(task.next_run_time or None)
         if old_timestamp == new_timestamp:
             self.tasks[old_index] = (task, new_timestamp)
@@ -70,7 +72,7 @@ class MemoryStore(BaseStore):
 
         index = self.get_task_index(timestamp, task_id)
         del self.tasks[index]
-        del self.tasks_index[task.id]
+        del self.tasks_index[task_id]
 
     def remove_all_tasks(self) -> None:
         self.tasks = []
@@ -94,9 +96,9 @@ class MemoryStore(BaseStore):
                 high = mid
             elif mid_timestamp < timestamp:
                 low = mid + 1
-            elif mid_task.id > task_id:
+            elif mid_task.id > task_id:  # type: ignore
                 high = mid
-            elif mid_task.id < task_id:
+            elif mid_task.id < task_id:  # type: ignore
                 low = mid + 1
             else:
                 return mid

--- a/asyncz/stores/memory.py
+++ b/asyncz/stores/memory.py
@@ -34,7 +34,7 @@ class MemoryStore(BaseStore):
         return pending
 
     def get_next_run_time(self) -> Optional[datetime]:
-        return self.tasks[0][0].next_run_time if self.tasks else None
+        return (self.tasks[0][0].next_run_time or None) if self.tasks else None
 
     def get_all_tasks(self) -> List["TaskType"]:
         return [task[0] for task in self.tasks]
@@ -43,7 +43,7 @@ class MemoryStore(BaseStore):
         if task.id in self.tasks_index:
             raise ConflictIdError(task.id)
 
-        timestamp = datetime_to_utc_timestamp(task.next_run_time)
+        timestamp = datetime_to_utc_timestamp(task.next_run_time or None)
         index = self.get_task_index(timestamp, task.id)
 
         self.tasks.insert(index, (task, timestamp))
@@ -55,7 +55,7 @@ class MemoryStore(BaseStore):
             raise TaskLookupError(task.id)
 
         old_index = self.get_task_index(old_timestamp, old_task.id)
-        new_timestamp = datetime_to_utc_timestamp(task.next_run_time)
+        new_timestamp = datetime_to_utc_timestamp(task.next_run_time or None)
         if old_timestamp == new_timestamp:
             self.tasks[old_index] = (task, new_timestamp)
         else:

--- a/asyncz/stores/redis.py
+++ b/asyncz/stores/redis.py
@@ -104,6 +104,7 @@ class RedisStore(BaseStore):
         return sorted(tasks, key=lambda task: task.next_run_time or paused_sort_key)
 
     def add_task(self, task: "TaskType") -> None:
+        assert task.id
         if self.redis.hexists(self.tasks_key, task.id):
             raise ConflictIdError(task.id)
 
@@ -123,6 +124,7 @@ class RedisStore(BaseStore):
             pipe.execute()  # type: ignore
 
     def update_task(self, task: "TaskType") -> None:
+        assert task.id
         if not self.redis.hexists(self.tasks_key, task.id):
             raise TaskLookupError(task.id)
 

--- a/asyncz/stores/redis.py
+++ b/asyncz/stores/redis.py
@@ -58,7 +58,7 @@ class RedisStore(BaseStore):
 
     def rebuild_task(self, state: Any) -> "TaskType":
         state = pickle.loads(self.conditional_decrypt(state))
-        task = Task.__new__(TaskType)
+        task = Task.__new__(Task)
         task.__setstate__(state)
         task.scheduler = cast("SchedulerType", self.scheduler)
         task.store_alias = self.alias

--- a/asyncz/tasks/base.py
+++ b/asyncz/tasks/base.py
@@ -61,17 +61,15 @@ class Task(BaseState, TaskType):  # type: ignore
 
     def __init__(
         self,
-        scheduler: Optional[SchedulerType] = None,
-        id: Optional[str] = None,
-        store_alias: Optional[str] = None,
-        *,
         fn: Union[Callable[..., Any], str, None] = None,
+        *,
+        id: Optional[str] = None,
         **kwargs: Any,
     ):
         if id is None and fn is not None:
             id = uuid4().hex
         super().__init__(id=id, **kwargs)
-        self.update_task(fn=fn, scheduler=scheduler, store_alias=store_alias, **kwargs)
+        self.update_task(fn=fn, **kwargs)
 
     def get_run_times(self, now: datetime) -> List[datetime]:
         """
@@ -94,7 +92,7 @@ class Task(BaseState, TaskType):  # type: ignore
         """
         approved: Dict[str, Any] = {}
         if scheduler is not None:
-            if self.scheduler is not None:
+            if self.scheduler is not None and self.scheduler is not scheduler:
                 raise ValueError("The task scheduler may not be changed.")
             approved["scheduler"] = scheduler
         else:

--- a/asyncz/tasks/base.py
+++ b/asyncz/tasks/base.py
@@ -68,7 +68,9 @@ class Task(BaseState, TaskType):  # type: ignore
         fn: Union[Callable[..., Any], str, None] = None,
         **kwargs: Any,
     ):
-        super().__init__(id=id or uuid4().hex, **kwargs)
+        if id is None and fn is not None:
+            id = uuid4().hex
+        super().__init__(id=id, **kwargs)
         self.update_task(fn=fn, scheduler=scheduler, store_alias=store_alias, **kwargs)
 
     def get_run_times(self, now: datetime) -> List[datetime]:
@@ -249,6 +251,8 @@ class Task(BaseState, TaskType):  # type: ignore
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Task):
+            if self.id is None:
+                return False
             return self.id == other.id
         return NotImplemented
 

--- a/asyncz/tasks/types.py
+++ b/asyncz/tasks/types.py
@@ -1,3 +1,87 @@
-from asyncz.tasks import Task
+from __future__ import annotations
 
-TaskType = Task
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Optional,
+)
+
+from asyncz.schedulers.types import SchedulerType
+
+if TYPE_CHECKING:
+    from asyncz.triggers.types import TriggerType
+
+
+class TaskType(ABC):
+    """BaseType of task."""
+
+    id: str
+    name: Optional[str] = None
+    next_run_time: Optional[datetime] = None
+    store_alias: Optional[str] = None
+    scheduler: Optional[SchedulerType] = None
+
+    @property
+    def pending(self) -> bool:
+        """
+        Returns true if the referenced task is still waiting to be added to its designated task
+        store.
+        """
+        return self.store_alias is None
+
+    @abstractmethod
+    def update(self, **updates: Any) -> TaskType:
+        """
+        Makes the given updates to this json and save it in the associated store.
+        Accepted keyword args are the same as the class variables.
+        """
+
+    def reschedule(self, trigger: TriggerType, **trigger_args: Any) -> TaskType:
+        """
+        Shortcut for switching the trigger on this task.
+        """
+        scheduler = self.scheduler
+        if scheduler is not None:
+            scheduler.reschedule_task(self.id, self.store_alias, trigger, **trigger_args)
+        return self
+
+    def pause(self) -> TaskType:
+        """
+        Temporarily suspenses the execution of a given task.
+        """
+        scheduler = self.scheduler
+        if scheduler is not None:
+            scheduler.pause_task(self.id, self.store_alias)
+        return self
+
+    def resume(self) -> TaskType:
+        """
+        Resume the schedule of this task if previously paused.
+        """
+        scheduler = self.scheduler
+        if scheduler is not None:
+            scheduler.resume_task(self.id, self.store_alias)
+        return self
+
+    def delete(self) -> TaskType:
+        """
+        Unschedules this task and removes it from its associated store.
+        """
+        scheduler = self.scheduler
+        if scheduler is not None:
+            scheduler.delete_task(self.id, self.store_alias)
+        return self
+
+    @abstractmethod
+    def get_run_times(self, now: datetime) -> List[datetime]:
+        """
+        Computes the scheduled run times `next_run_time` and `now`, inclusive.
+        """
+
+    def __call__(self, fn: Callable[..., Any]) -> Callable:
+        self._update(fn=fn)
+        return fn

--- a/asyncz/triggers/date.py
+++ b/asyncz/triggers/date.py
@@ -18,6 +18,7 @@ class DateTrigger(BaseTrigger):
     """
 
     alias: ClassVar[str] = "date"
+    run_at: datetime
 
     def __init__(
         self,
@@ -25,12 +26,13 @@ class DateTrigger(BaseTrigger):
         timezone: Optional[Union[tzinfo, str]] = None,
         **kwargs: Any,
     ):
-        super().__init__(**kwargs)
         timezone = to_timezone(timezone) or get_localzone()
         if run_at is not None:
-            self.run_at = to_datetime(run_at, timezone, "run_at")
+            kwargs["run_at"] = to_datetime(run_at, timezone, "run_at")
         else:
-            self.run_at = datetime.now(timezone)
+            kwargs["run_at"] = datetime.now(timezone)
+            kwargs["allow_misstrigger_by_default"] = True
+        super().__init__(**kwargs)
 
     def get_next_trigger_time(
         self, previous_time: Optional[datetime], now: Optional[datetime] = None

--- a/asyncz/triggers/types.py
+++ b/asyncz/triggers/types.py
@@ -6,6 +6,7 @@ from typing import ClassVar, Optional, Union, overload
 class TriggerType(ABC):
     alias: ClassVar[str]
     jitter: Optional[int] = None
+    allow_misstrigger_by_default: bool = False
 
     @abstractmethod
     def get_next_trigger_time(

--- a/docs/asgi.md
+++ b/docs/asgi.md
@@ -1,0 +1,87 @@
+
+# ASGI and contexmanager
+
+The scheduler uses refcounting for start and stop calls. Only if refs drop to 0 it is shutdown.
+This way it is compatible to lifespan and nested contextmanager calls.
+
+=== "Wrapping an asgi application"
+
+    ```python
+    from asyncz.schedulers import AsyncIOScheduler
+    ...
+
+    # handle_lifespan is optional, set to True if you don't want to pass it down because the underlying app doesn't support it
+    # this is true for django
+    application = AsyncIOScheduler().asgi(application, handle_lifespan=False)
+    # or more simple (please do not use both together)
+    application = AsyncIOScheduler().asgi()(application)
+    ```
+
+=== "Using with lilya"
+
+    ```python
+    from asyncz.schedulers import AsyncIOScheduler
+
+    # Lilya middleware doesn't pass lifespan events
+
+    app = AsyncIOScheduler().asgi(Lilya(
+        routes=[...],
+    ))
+
+    ```
+
+    Or manually:
+
+    ```python
+    from asyncz.schedulers import AsyncIOScheduler
+
+    scheduler = AsyncIOScheduler()
+
+    app = Lilya(
+        routes=[...],
+        on_startup=[scheduler.start],
+        on_shutdown=[scheduler.shutdown],
+    )
+
+    ```
+
+
+## Contextmanager support
+
+=== "Use as sync contextmanager"
+
+    ```python
+    from asyncz.schedulers import AsyncIOScheduler
+
+    with AsyncIOScheduler() as scheduler:
+        ...
+    ```
+
+=== "Use as async contextmanager"
+
+    ```python
+    from asyncz.schedulers import AsyncIOScheduler
+
+    async with AsyncIOScheduler() as scheduler:
+        ...
+    ```
+
+
+For using with lifespan of starlette
+
+
+=== "Starlette"
+
+    ```python
+    from asyncz.schedulers import AsyncIOScheduler
+
+    async lifespan(app):
+        with AsyncIOScheduler() as scheduler:
+            yield
+            # or yield a state
+    app = Starlette(
+        lifespan=lifespan,
+    )
+
+
+    ```

--- a/docs/asgi.md
+++ b/docs/asgi.md
@@ -1,5 +1,5 @@
 
-# ASGI and contexmanager
+# ASGI and Contextmanager
 
 The scheduler uses refcounting for start and stop calls. Only if refs drop to 0 it is shutdown.
 This way it is compatible to lifespan and nested contextmanager calls.
@@ -54,7 +54,9 @@ This way it is compatible to lifespan and nested contextmanager calls.
     from asyncz.schedulers import AsyncIOScheduler
 
     with AsyncIOScheduler() as scheduler:
-        ...
+        # nesting is no problem
+        with AsyncIOScheduler() as scheduler2:
+            ...
     ```
 
 === "Use as async contextmanager"
@@ -63,7 +65,9 @@ This way it is compatible to lifespan and nested contextmanager calls.
     from asyncz.schedulers import AsyncIOScheduler
 
     async with AsyncIOScheduler() as scheduler:
-        ...
+        # nesting is no problem
+        async with AsyncIOScheduler() as scheduler2:
+            ...
     ```
 
 
@@ -82,6 +86,4 @@ For using with lifespan of starlette
     app = Starlette(
         lifespan=lifespan,
     )
-
-
     ```

--- a/docs/contrib/esmerald/decorator.md
+++ b/docs/contrib/esmerald/decorator.md
@@ -4,7 +4,7 @@ The decorator is a wrapper provided by Asyncz to Esmerald that allows you to dec
 anywhere and import them into the [EsmeraldScheduler](./scheduler.md) upont instantiation.
 
 In the end, the scheduler is a wrapper on te top of the [Task](../../tasks.md) object but not the
-same as the [scheduled_tasks](../../schedulers.md#scheduled-tasks). The latter is to be used
+same as the [task decorator](../../schedulers.md#add-tasks-as-decorator). The latter is to be used
 outside of the Esmerald context.
 
 ## Parameters

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,20 @@
 # Release Notes
 
+## Unreleased
+
+### Added
+
+- Task are decorators now
+- Tasks can be added via add_task
+
+### Changed
+
+- Task id can be None
+
+### Removed
+
+- schedule_task call (superseeded by add_task overloads)
+
 ## 0.9.0
 
 ### Added

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,10 +6,14 @@
 
 - Task are decorators now
 - Tasks can be added via add_task
+- Trigger can now overwrite mistrigger_grace_time via allow_misstrigger_by_default
+- Pools can now overwrite wait, and set cancel_futures
 
 ### Changed
 
-- Task id can be None
+- Task id can be None (decorator mode)
+- Task have now pending attribute
+- Tasks work more independent of schedulers
 
 ### Removed
 

--- a/docs/schedulers.md
+++ b/docs/schedulers.md
@@ -114,7 +114,7 @@ A scheduler to work needs tasks, of course and Asyncz offers some ways of adding
 scheduler.
 
 * [add_tasks](#add-tasks)
-* [scheduled_tasks](#scheduled-tasks)
+* [add tasks as decorator](#add-tasks-as-decorator)
 
 There is also a third option but that is related with the integration with ASGI frameworks, for
 instance [esmerald](./contrib/esmerald/decorator.md) which it should not be used in this agnostic
@@ -122,8 +122,7 @@ context.
 
 ### Add tasks
 
-Adding a task via `add_task` is the most common and probably the one you will be using more times
-than the `scheduled_task`.
+Adding a task via `add_task` is the most common.
 
 **The `add_task` returns an instance of [Task](./tasks.md).**
 
@@ -146,13 +145,14 @@ and simpler.
 When adding tasks there is not a specific order. **You can add tasks at any given time**. If the
 scheduler is not yet running, once it does it will add the tasks to it.
 
-## Scheduled tasks
+## Add tasks as decorator
 
-Scheduled tasks works in the same way as [add_tasks](#add-tasks) with the **unique difference** that
-the `replacing_existing` is always `True` and it is used as a decorator.
+When leaving out the `fn` parameter, you get back a decorator type Task. When decorating a function it is with
+`replacing_existing=True` added to the task queue.
+When also leaving out the `id` parameter a new Task object is created.
 
 ```python hl_lines="10-12 19-23 29-33"
-{!> ../docs_src/schedulers/scheduled_task.py !}
+{!> ../docs_src/schedulers/add_task_decorator.py !}
 ```
 
 ## Deleting tasks
@@ -175,7 +175,7 @@ store alias.
 ## Delete
 
 The `delete` function is probably more convenient but it requires that you store the [Task](./tasks.md)
-somewhere ocne the instance is received and for tasks scheduled by [scheduled task](#scheduled-tasks)
+somewhere ocne the instance is received and for tasks scheduled by the[task decorator](#add-tasks-as-decorator)
 this method does not work, instead only the [delete task](#delete-task) will work.
 
 ```python hl_lines="23 29"

--- a/docs/stores.md
+++ b/docs/stores.md
@@ -2,7 +2,7 @@
 
 In simple terms, the stores are places where, as the name suggests, stores the scheduled tasks.
 Asyncz has a `default` store wich is a [MemoryStore](#memorystore) but also brings an integration
-with two major ones, [Redis](#redisstore) and [MongoDB](#mongodbstore).
+with three major ones, [Redis](#redisstore), [SQLAlchemy](#sqlalchemystore) and [MongoDB](#mongodbstore).
 
 Besides the default memory store, the tasks are not store in memory but in the corresponding desired
 store.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -54,11 +54,3 @@ The trigger must be the [alias of the trigger object](./triggers.md#alias).
 ```python hl_lines="26-30"
 {!> ../docs_src/tasks/reschedule_task.py !}
 ```
-
-
-## Note
-
-These is in raw terms what a task instance does and how to create a task but 99% of the times you
-will not work directly with a task instance like this, instead, you will be creating a task using the
-[scheduler](./schedulers.md#adding-tasks) to help you out and it is **strongly advised** to use
-the scheduler and the operations via scheduler instead of working directly via task instance.

--- a/docs_src/schedulers/add_task.py
+++ b/docs_src/schedulers/add_task.py
@@ -72,7 +72,7 @@ task = Task(
 )
 scheduler.add_task(task)
 
-# Use Task as decorator (leave function empty)
+# Use Task as decorator (leave fn empty)
 decorator = scheduler.add_task(
     args=[feed_data],
     trigger=IntervalTrigger(minutes=10),

--- a/docs_src/schedulers/add_task.py
+++ b/docs_src/schedulers/add_task.py
@@ -2,6 +2,7 @@ from datetime import timezone as tz
 
 from asyncz.schedulers.asyncio import AsyncIOScheduler
 from asyncz.triggers import CronTrigger, IntervalTrigger
+from asyncz.tasks import Task
 
 # Create the scheduler
 scheduler = AsyncIOScheduler(timezone=tz.utc)
@@ -58,6 +59,28 @@ scheduler.add_task(
     replace_existing=True,
     coalesce=False,
 )
+
+# Add Task object
+
+task = Task(
+    fn=send_email_newsletter,
+    args=[feed_data],
+    trigger=IntervalTrigger(minutes=10),
+    max_instances=1,
+    replace_existing=True,
+    coalesce=False,
+)
+scheduler.add_task(task)
+
+# Use Task as decorator (leave function empty)
+decorator = scheduler.add_task(
+    args=[feed_data],
+    trigger=IntervalTrigger(minutes=10),
+    max_instances=1,
+    replace_existing=True,
+    coalesce=False,
+)
+decorator(send_email_newsletter)
 
 
 # Start the scheduler

--- a/docs_src/schedulers/add_task_decorator.py
+++ b/docs_src/schedulers/add_task_decorator.py
@@ -8,7 +8,7 @@ scheduler = AsyncIOScheduler(timezone=tz.utc)
 
 
 # Run every Monday, Wednesday and Friday
-@scheduler.scheduled_task(
+@scheduler.add_task(
     trigger=CronTrigger(day_of_week="mon,wed,fri", hour="8", minute="1", second="5")
 )
 def send_email_newsletter():
@@ -17,7 +17,7 @@ def send_email_newsletter():
 
 
 # Run every 2 minutes
-@scheduler.scheduled_task(
+@scheduler.add_task(
     trigger=IntervalTrigger(minutes=2),
     max_instances=1,
     coalesce=True,
@@ -27,7 +27,7 @@ def collect_www_info():
     ...
 
 
-@scheduler.scheduled_task(
+@scheduler.add_task(
     trigger=IntervalTrigger(minutes=10),
     max_instances=1,
     coalesce=False,

--- a/docs_src/schedulers/delete_task.py
+++ b/docs_src/schedulers/delete_task.py
@@ -31,12 +31,12 @@ scheduler.add_task(
 )
 
 # Run every hour and minute 1
-scheduler.add_task(
+status = scheduler.add_task(
     id="status",
     fn=check_status,
     trigger=CronTrigger(hour="0-23", minute="1"),
 )
 
-# Remove the tasks by ID and store alias
+# Remove the tasks by ID or task object
 scheduler.delete_task("send_newsletter")
-scheduler.delete_task("status")
+scheduler.delete_task(status)

--- a/docs_src/schedulers/pause_task.py
+++ b/docs_src/schedulers/pause_task.py
@@ -26,7 +26,7 @@ scheduler.add_task(
 )
 
 # Run every hour and minute 1
-scheduler.add_task(
+status = scheduler.add_task(
     id="status",
     fn=check_status,
     trigger=CronTrigger(hour="0-23", minute="1"),
@@ -34,4 +34,4 @@ scheduler.add_task(
 
 # Pause the tasks by ID and store alias
 scheduler.pause_task("send_newsletter")
-scheduler.pause_task("status")
+scheduler.pause_task(status)

--- a/docs_src/schedulers/reschedule_task.py
+++ b/docs_src/schedulers/reschedule_task.py
@@ -26,7 +26,7 @@ scheduler.add_task(
 )
 
 # Run every 10 minutes
-scheduler.add_task(
+check_status = scheduler.add_task(
     id="check_status",
     fn=check_status,
     trigger=IntervalTrigger(minutes=10),
@@ -37,7 +37,7 @@ scheduler.add_task(
 
 # Reschedule the tasks
 scheduler.reschedule_task("send_email_newsletter", trigger="cron", day_of_week="mon", hour="1")
-scheduler.reschedule_task("check_status", trigger="interval", minutes=20)
+scheduler.reschedule_task(check_status, trigger="interval", minutes=20)
 
 # Start the scheduler
 scheduler.start()

--- a/docs_src/schedulers/resume_task.py
+++ b/docs_src/schedulers/resume_task.py
@@ -26,12 +26,12 @@ scheduler.add_task(
 )
 
 # Run every hour and minute 1
-scheduler.add_task(
+status = scheduler.add_task(
     id="status",
     fn=check_status,
     trigger=CronTrigger(hour="0-23", minute="1"),
 )
 
-# Resume the tasks by ID and store alias
+# Resume the tasks by ID or task object
 scheduler.resume_task("send_newsletter")
-scheduler.resume_task("status")
+scheduler.resume_task(status)

--- a/docs_src/schedulers/update_task.py
+++ b/docs_src/schedulers/update_task.py
@@ -26,7 +26,7 @@ scheduler.add_task(
 )
 
 # Run every 10 minutes
-scheduler.add_task(
+check_status = scheduler.add_task(
     id="check_status",
     fn=check_status,
     trigger=IntervalTrigger(minutes=10),
@@ -35,9 +35,9 @@ scheduler.add_task(
     coalesce=False,
 )
 
-# Update the task
+# Update the task by id or object
 scheduler.update_task("send_email_newsletter", coalesce=False, max_instances=4)
-scheduler.update_task("check_status", coalesce=True, max_instances=3)
+scheduler.update_task(check_status, coalesce=True, max_instances=3)
 
 # Start the scheduler
 scheduler.start()

--- a/docs_src/triggers/date/example1.py
+++ b/docs_src/triggers/date/example1.py
@@ -12,6 +12,6 @@ def my_task(number):
 
 
 # Execute the task on December 25th, 2022
-scheduler.add_task(my_task, run_date=date(2022, 12, 24), args=[25])
+scheduler.add_task(my_task, run_at=date(2022, 12, 24), args=[25])
 
 scheduler.start()

--- a/docs_src/triggers/date/example2.py
+++ b/docs_src/triggers/date/example2.py
@@ -10,6 +10,6 @@ def my_task(number):
 
 
 # Execute the task on December 25th, 2022
-scheduler.add_task(my_task, run_date="2022-12-25 00:01:00", args=[25])
+scheduler.add_task(my_task, run_at="2022-12-25 00:01:00", args=[25])
 
 scheduler.start()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,8 +48,7 @@ nav:
           - Overview: "contrib/esmerald/index.md"
           - Scheduler: "contrib/esmerald/scheduler.md"
           - Decorator: "contrib/esmerald/decorator.md"
-      - ASGI:
-          - asgi.md
+      - asgi.md
   - Contributing: "contributing.md"
   - Vendors: "vendors.md"
   - Sponsorship: "sponsorship.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,8 @@ nav:
           - Overview: "contrib/esmerald/index.md"
           - Scheduler: "contrib/esmerald/scheduler.md"
           - Decorator: "contrib/esmerald/decorator.md"
+      - ASGI:
+          - asgi.md
   - Contributing: "contributing.md"
   - Vendors: "vendors.md"
   - Sponsorship: "sponsorship.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,8 +33,7 @@ repo_url: https://github.com/dymmond/asyncz
 edit_uri: ""
 plugins:
   - search
-  - markdownextradata:
-      data: data
+  - macros
 
 nav:
   - Asyncz: "index.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ dependencies = [
     "mkdocs >=1.1.2,<2.0.0",
     "mkdocs-material >=9.0.13,<10.0.0",
     "mdx-include >=1.4.2,<2.0.0",
-    "mkdocs-markdownextradata-plugin >=0.2.5,<0.3.0",
+    "mkdocs-macros-plugin >=1.0.0,<2.0.0",
     "mkdocstrings>=0.20.0,<0.30.0",
     "pyyaml >=6.0,<7.0.0",
 ]

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -423,6 +423,24 @@ class TestBaseScheduler:
 
         assert task.next_run_time.tzinfo.zone == timezone.zone
 
+    def test_add_task_obj_return_value(self, scheduler, timezone):
+        """Test that when a task is added to a stopped scheduler, a Task instance is returned."""
+        task = Task(
+            fn=lambda x, y: None,
+            id="my-id",
+            name="dummy",
+            args=[1],
+            kwargs={"y": 2},
+        )
+        task = scheduler.add_task(task, trigger="date", run_at="2020-06-01 08:41:00")
+
+        assert isinstance(task, Task)
+        assert task.id == "my-id"
+
+        assert task.mistrigger_grace_time == 1
+        assert task.coalesce is True
+        assert task.max_instances == 1
+
     def test_add_task_pending(self, scheduler, scheduler_events):
         scheduler.setup(
             task_defaults={

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -359,6 +359,8 @@ class TestBaseScheduler:
     def test_add_store(self, scheduler, scheduler_events, start_scheduler):
         if start_scheduler:
             scheduler.start()
+        else:
+            scheduler.wakeup = MagicMock().assert_not_called()
 
         del scheduler_events[:]
         store = DummyStore()

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -42,7 +42,6 @@ from asyncz.stores.memory import MemoryStore
 from asyncz.tasks import Task
 from asyncz.tasks.types import TaskType
 from asyncz.triggers.base import BaseTrigger
-from asyncz.typing import undefined
 
 try:
     from zoneinfo import ZoneInfo
@@ -483,39 +482,25 @@ class TestBaseScheduler:
         tasks = scheduler.get_tasks()
         assert len(tasks) == 1
         assert tasks[0].name == "original"
+
         def fn():
             return None
+
         assert decorator(fn) is fn
         tasks = scheduler.get_tasks()
         assert len(tasks) == 1
         assert tasks[0].name == "replacement"
 
-
-    def test_scheduled_task(self, scheduler):
+    def test_add_task_to_decorator(self, scheduler):
         def fn(x, y): ...
 
-        object_setter(scheduler, "add_task", MagicMock())
-        decorator = scheduler.scheduled_task(
-            "date", [1], {"y": 2}, "my-id", "dummy", run_at="2022-06-01 08:41:00"
+        decorator = scheduler.add_task(
+            None, "date", [1], {"y": 2}, "my-id", "dummy", run_at="2022-06-01 08:41:00"
         )
+        object_setter(scheduler, "add_task", MagicMock())
         decorator(fn)
 
-        scheduler.add_task.assert_called_once_with(
-            fn=fn,
-            trigger="date",
-            args=[1],
-            kwargs={"y": 2},
-            id="my-id",
-            name="dummy",
-            mistrigger_grace_time=undefined,
-            coalesce=undefined,
-            max_instances=undefined,
-            next_run_time=undefined,
-            store="default",
-            executor="default",
-            replace_existing=True,
-            run_at="2022-06-01 08:41:00",
-        )
+        scheduler.add_task.assert_called_once()
 
     @pytest.mark.parametrize("pending", [True, False], ids=["pending task", "scheduled task"])
     def test_update_task(self, scheduler, pending, timezone):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -175,8 +175,8 @@ def test_private_update_bad_next_run_time(task):
 
 
 def test_private_update_bad_argument(task):
-    exc = pytest.raises(AttributeError, task._update, scheduler=1)
-    assert str(exc.value) == "The following are not modifiable attributes of Task: scheduler."
+    exc = pytest.raises(ValueError, task._update, scheduler=1)
+    assert str(exc.value) == "The task scheduler may not be changed."
 
 
 def test_getstate(task):
@@ -253,14 +253,12 @@ def test_repr(task):
     ],
     ids=["scheduled", "paused", "pending"],
 )
-@pytest.mark.parametrize("unicode", [False, True], ids=["nativestr", "unicode"])
-def test_str(create_task, status, unicode, expected_status):
+def test_str(create_task, status, expected_status):
     task = create_task(fn=dummyfn)
     if status == "scheduled":
         task.next_run_time = task.trigger.run_at
     elif status == "pending":
-        del task.next_run_time
-
+        task.scheduler = None
     expected = (
         b"n\xc3\xa4m\xc3\xa9 (trigger: date[2022-11-03 18:40:00 GMT], %s)".decode("utf-8")
         % expected_status

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,7 +25,7 @@ def task(create_task):
 @pytest.mark.parametrize("task_id", ["testid", None])
 def test_constructor(task_id):
     scheduler_mock = MagicMock(BaseScheduler)
-    task = Task(scheduler_mock, id=task_id)
+    task = Task(scheduler_mock, id=task_id, fn=lambda: None)
     assert task.scheduler is scheduler_mock
     assert task.store_alias is None
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -25,7 +25,7 @@ def task(create_task):
 @pytest.mark.parametrize("task_id", ["testid", None])
 def test_constructor(task_id):
     scheduler_mock = MagicMock(BaseScheduler)
-    task = Task(scheduler_mock, id=task_id, fn=lambda: None)
+    task = Task(scheduler=scheduler_mock, id=task_id, fn=lambda: None)
     assert task.scheduler is scheduler_mock
     assert task.store_alias is None
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -70,13 +70,6 @@ def test_weakref(create_task):
     assert ref() is None
 
 
-def test_pending(task):
-    assert task.pending
-
-    task.store_alias = "test"
-    assert not task.pending
-
-
 def test_get_run_times(create_task, timezone):
     run_time = timezone.localize(datetime(2023, 12, 13, 0, 8))
     expected_times = [run_time + timedelta(seconds=1), run_time + timedelta(seconds=2)]
@@ -103,79 +96,81 @@ def test_create_bad_id(create_task):
 
 
 def test_private_update_id(task):
-    exc = pytest.raises(ValueError, task._update, id="alternate")
+    exc = pytest.raises(ValueError, task.update_task, id="alternate")
     assert str(exc.value) == "The task ID may not be changed."
 
 
 def test_private_update_bad_fn(task):
-    exc = pytest.raises(TypeError, task._update, fn=1)
+    exc = pytest.raises(TypeError, task.update_task, fn=1)
     assert str(exc.value) == "fn must be a callable or a textual reference to a callable."
 
 
 def test_private_update_func_ref(task):
-    task._update(fn="tests.test_tasks:dummyfn")
+    task.update_task(fn="tests.test_tasks:dummyfn")
     assert task.fn is dummyfn
     assert task.fn_reference == "tests.test_tasks:dummyfn"
 
 
 def test_private_update_unreachable_fn(task):
     fn = partial(dummyfn)
-    task._update(fn=fn)
+    task.update_task(fn=fn)
     assert task.fn is fn
     assert task.fn_reference is None
 
 
 def test_private_update_name(task):
     del task.name
-    task._update(fn=dummyfn)
+    task.update_task(fn=dummyfn)
     assert task.name == "dummyfn"
 
 
 def test_private_update_bad_args(task):
-    exc = pytest.raises(TypeError, task._update, args=1)
+    exc = pytest.raises(TypeError, task.update_task, args=1)
     assert str(exc.value) == "args must be a non-string iterable."
 
 
 def test_private_update_bad_kwargs(task):
-    exc = pytest.raises(TypeError, task._update, kwargs=1)
+    exc = pytest.raises(TypeError, task.update_task, kwargs=1)
     assert str(exc.value) == "kwargs must be a dict-like object."
 
 
 @pytest.mark.parametrize("value", [1, ""], ids=["integer", "empty string"])
 def test_private_update_bad_name(task, value):
-    exc = pytest.raises(TypeError, task._update, name=value)
+    exc = pytest.raises(TypeError, task.update_task, name=value)
     assert str(exc.value) == "name must be a non empty string."
 
 
 @pytest.mark.parametrize("value", ["foo", 0, -1], ids=["string", "zero", "negative"])
 def test_private_update_bad_misfire_grace_time(task, value):
-    exc = pytest.raises(TypeError, task._update, mistrigger_grace_time=value)
-    assert str(exc.value) == "mistrigger_grace_time must be either None or a positive integer."
+    exc = pytest.raises(TypeError, task.update_task, mistrigger_grace_time=value)
+    assert (
+        str(exc.value) == "mistrigger_grace_time must be either None or a positive float/integer."
+    )
 
 
 @pytest.mark.parametrize("value", [None, "foo", 0, -1], ids=["None", "string", "zero", "negative"])
 def test_private_update_bad_max_instances(task, value):
-    exc = pytest.raises(TypeError, task._update, max_instances=value)
+    exc = pytest.raises(TypeError, task.update_task, max_instances=value)
     assert str(exc.value) == "max_instances must be a positive integer."
 
 
 def test_private_update_bad_trigger(task):
-    exc = pytest.raises(TypeError, task._update, trigger="foo")
+    exc = pytest.raises(TypeError, task.update_task, trigger="foo")
     assert str(exc.value) == "Expected a trigger instance, got str instead."
 
 
 def test_private_update_bad_executor(task):
-    exc = pytest.raises(TypeError, task._update, executor=1)
+    exc = pytest.raises(TypeError, task.update_task, executor=1)
     assert str(exc.value) == "executor must be a string."
 
 
 def test_private_update_bad_next_run_time(task):
-    exc = pytest.raises(AsynczException, task._update, next_run_time=1)
+    exc = pytest.raises(AsynczException, task.update_task, next_run_time=1)
     assert str(exc.value) == "Unsupported type for next_run_time: int."
 
 
 def test_private_update_bad_argument(task):
-    exc = pytest.raises(ValueError, task._update, scheduler=1)
+    exc = pytest.raises(ValueError, task.update_task, scheduler=1)
     assert str(exc.value) == "The task scheduler may not be changed."
 
 
@@ -255,10 +250,11 @@ def test_repr(task):
 )
 def test_str(create_task, status, expected_status):
     task = create_task(fn=dummyfn)
+    task.pending = False
     if status == "scheduled":
         task.next_run_time = task.trigger.run_at
     elif status == "pending":
-        task.scheduler = None
+        task.pending = True
     expected = (
         b"n\xc3\xa4m\xc3\xa9 (trigger: date[2022-11-03 18:40:00 GMT], %s)".decode("utf-8")
         % expected_status


### PR DESCRIPTION
Changes:
- add_task supports now Task elements
- Tasks can decorate functions which makes scheduled_task obsolete (removed)
- improve typings
- Tasks have now no extra attributes anymore
- docs improvements
- fix calling add_store on a stopped scheduler calling wakeup (crash when no eventloop was created yet)
- allow trigger changing default of mistrigger_grace_time to None (for simple bg tasks)