### PR TITLE
optional loguru, allow switching logging

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -18,6 +18,17 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    services:
+      redis:
+        image: redis
+        ports:
+          - 127.0.0.1:6379:6379
+
+      mongodb:
+        image: mongo
+        ports:
+          - 127.0.0.1:27017:27017
+
     steps:
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v5"
@@ -29,14 +40,12 @@ jobs:
         with:
           path: ${{ env.pythonLocation }}
           key: ${{ runner.os }}-python-${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-test-v02
-      - name: "Start docker services"
-        run: docker-compose up -d
       - name: "Install dependencies"
         if: steps.cache.outputs.cache-hit != 'true'
         run: "pip install hatch"
       - name: "Run linting"
         run: "hatch fmt --check"
-      # - name: "Run mypy"
-      #  run: "hatch run test:check_types"
+      - name: "Run mypy"
+        run: "hatch run test:check_types"
       - name: "Run tests"
         run: "hatch test"

--- a/asyncz/executors/__init__.py
+++ b/asyncz/executors/__init__.py
@@ -1,7 +1,8 @@
 from .asyncio import AsyncIOExecutor
 from .base import BaseExecutor
 from .debug import DebugExecutor
-from .pool import ProcessPoolExecutor, ThreadPoolExecutor
+from .pool import ThreadPoolExecutor
+from .process_pool import ProcessPoolExecutor
 
 __all__ = [
     "BaseExecutor",

--- a/asyncz/executors/debug.py
+++ b/asyncz/executors/debug.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, cast
 
 from asyncz.executors.base import BaseExecutor, run_task
 
@@ -19,8 +19,9 @@ class DebugExecutor(BaseExecutor):
         run_times: List[datetime],
     ) -> None:
         assert task.id is not None, "Cannot send decorator type task"
+        assert self.logger is not None, "logger is None"
         try:
-            events = run_task(task, task.store_alias, run_times, self.logger)  # type: ignore
+            events = run_task(task, cast(str, task.store_alias), run_times, self.logger)
         except Exception:
             self.run_task_error(task.id)
         else:

--- a/asyncz/executors/process_pool.py
+++ b/asyncz/executors/process_pool.py
@@ -1,0 +1,81 @@
+import concurrent.futures
+from multiprocessing import Pipe, connection
+from threading import Thread
+from typing import TYPE_CHECKING, Any, Optional, cast
+
+from asyncz.executors.pool import BasePoolExecutor
+
+if TYPE_CHECKING:
+    import logging
+
+    from asyncz.schedulers.types import SchedulerType
+
+# because multiprocessing is heavy weight, it is split out from pool
+
+
+class ProcessPoolLoggerSenderFnWrap:
+    def __init__(self, send_pipe: connection.Connection, fn_name: str) -> None:
+        self.send_pipe = send_pipe
+        self.fn_name = fn_name
+
+    def __call__(self, *args: Any, **kwargs: Any) -> None:
+        self.send_pipe.send((self.fn_name, args, kwargs))
+
+
+class ProcessPoolLoggerSender:
+    def __init__(self, send_pipe: connection.Connection) -> None:
+        self.send_pipe = send_pipe
+
+    def __getattr__(self, item: str) -> Any:
+        if item.startswith("_"):
+            return object.__getattr__(self, item)
+        return ProcessPoolLoggerSenderFnWrap(self.send_pipe, item)
+
+
+class ProcessPoolReceiver(Thread):
+    def __init__(self, receive_pipe: connection.Connection, logger: "logging.Logger") -> None:
+        super().__init__()
+        self.receive_pipe = receive_pipe
+        self.logger = logger
+        self.start()
+
+    def run(self) -> None:
+        try:
+            while True:
+                fn_name, args, kwargs = self.receive_pipe.recv()
+                if not fn_name.startswith("_"):
+                    getattr(self.logger, fn_name)(*args, **kwargs)
+        except EOFError:
+            pass
+
+
+class ProcessPoolExecutor(BasePoolExecutor):
+    """
+    An executor that runs tasks in a concurrent.futures process pool.
+
+    Args:
+        max_workers: The maximum number of spawned processes.
+        pool_kwargs: Dict of keyword arguments to pass to the underlying
+            ProcessPoolExecutor constructor.
+    """
+
+    def __init__(
+        self, max_workers: int = 10, pool_kwargs: Optional[Any] = None, **kwargs: Any
+    ) -> None:
+        self.receive_pipe, self.send_pipe = Pipe(False)
+        pool_kwargs = pool_kwargs or {}
+        pool = concurrent.futures.ProcessPoolExecutor(int(max_workers), **pool_kwargs)
+        super().__init__(pool, **kwargs)
+
+    def start(self, scheduler: "SchedulerType", alias: str) -> None:
+        super().start(scheduler, alias)
+        assert self.logger is not None, "logger is None"
+        # move the old logger to logger_receiver
+        self.logger_receiver = ProcessPoolReceiver(self.receive_pipe, self.logger)
+        # and send the process logger instead
+        self.logger = cast("logging.Logger", ProcessPoolLoggerSender(self.send_pipe))
+
+    def shutdown(self, wait: bool = True) -> None:
+        super().shutdown(wait=wait)
+        self.send_pipe.close()
+        self.logger_receiver.join()

--- a/asyncz/executors/types.py
+++ b/asyncz/executors/types.py
@@ -2,15 +2,19 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, List, Optional
 
 if TYPE_CHECKING:
+    import logging
+
     from asyncz.events import TaskExecutionEvent
     from asyncz.schedulers.types import SchedulerType
     from asyncz.tasks.types import TaskType
 
 
 class ExecutorType(ABC):
+    logger: Optional[logging.Logger]
+
     @abstractmethod
     def start(self, scheduler: SchedulerType, alias: str) -> None:
         """

--- a/asyncz/schedulers/defaults.py
+++ b/asyncz/schedulers/defaults.py
@@ -13,7 +13,7 @@ executors: Dict[str, str] = {
     "debug": "asyncz.executors.debug:DebugExecutor",
     "pool": "asyncz.executors.pool:ThreadPoolExecutor",
     "threadpool": "asyncz.executors.pool:ThreadPoolExecutor",
-    "processpool": "asyncz.executors.pool:ProcessPoolExecutor",
+    "processpool": "asyncz.executors.process_pool:ProcessPoolExecutor",
     "asyncio": "asyncz.executors.asyncio:AsyncIOExecutor",
 }
 

--- a/asyncz/schedulers/types.py
+++ b/asyncz/schedulers/types.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from asyncz.events.constants import (
     ALL_EVENTS,
@@ -10,6 +10,7 @@ from asyncz.typing import Undefined, undefined
 
 if TYPE_CHECKING:
     from datetime import datetime
+    from logging import Logger
     from threading import RLock
 
     from asyncz.events.base import SchedulerEvent
@@ -19,7 +20,22 @@ if TYPE_CHECKING:
     from asyncz.triggers.types import TriggerType
 
 
+class LoggersType(ABC):
+    def __init__(self) -> None:
+        self.data: Dict[str, Logger] = {}
+
+    @abstractmethod
+    def __missing__(self, item: str) -> Logger: ...
+
+    def __getitem__(self, item: str) -> Logger:
+        if item not in self.data:
+            self.data[item] = self.__missing__(item)
+        return self.data[item]
+
+
 class SchedulerType(ABC):
+    loggers: LoggersType
+
     @abstractmethod
     def start(self, paused: bool = False) -> bool:
         """

--- a/asyncz/stores/base.py
+++ b/asyncz/stores/base.py
@@ -3,7 +3,6 @@ import os
 from typing import TYPE_CHECKING, Any, List, Optional
 
 from cryptography.hazmat.primitives.ciphers.aead import AESCCM
-from loguru import logger
 
 from asyncz.state import BaseStateExtra
 from asyncz.stores.types import StoreType
@@ -18,10 +17,9 @@ class BaseStore(BaseStateExtra, StoreType):
     Base class for all task stores.
     """
 
-    def __init__(self, scheduler: Optional["SchedulerType"] = None, **kwargs: Any) -> None:
+    def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
-        self.scheduler = scheduler
-        self.logger = logger
+        self.scheduler: Optional[SchedulerType] = None
         self.encryption_key: Optional[AESCCM] = None
 
     def start(self, scheduler: "SchedulerType", alias: str) -> None:
@@ -35,6 +33,7 @@ class BaseStore(BaseStateExtra, StoreType):
         """
         self.scheduler = scheduler
         self.alias = alias
+        self.logger_name = f"asyncz.stores.{alias}"
         encryption_key = os.environ.get("ASYNCZ_STORE_ENCRYPTION_KEY")
         if encryption_key:
             # we simply use a hash. This way all kinds of tokens, lengths and co are supported

--- a/asyncz/stores/mongo.py
+++ b/asyncz/stores/mongo.py
@@ -88,7 +88,9 @@ class MongoDBStore(BaseStore):
                 tasks.append(self.rebuild_task(document["state"]))
             except BaseException:
                 doc_id = document["_id"]
-                self.logger.exception(f"Unable to restore task '{doc_id}'. Removing it...")
+                cast("SchedulerType", self.scheduler).loggers[self.logger_name].exception(
+                    f"Unable to restore task '{doc_id}'. Removing it..."
+                )
                 failed_task_ids.append(doc_id)
 
         if failed_task_ids:

--- a/asyncz/stores/redis.py
+++ b/asyncz/stores/redis.py
@@ -80,7 +80,9 @@ class RedisStore(BaseStore):
             try:
                 tasks.append(self.rebuild_task(state))
             except BaseException:
-                self.logger.exception(f"Unable to restore task '{task_id}'. Removing it...")
+                cast("SchedulerType", self.scheduler).loggers[self.logger_name].exception(
+                    f"Unable to restore task '{task_id}'. Removing it..."
+                )
                 failed_task_ids.append(task_id)
 
         if failed_task_ids:

--- a/asyncz/stores/sqlalchemy.py
+++ b/asyncz/stores/sqlalchemy.py
@@ -95,7 +95,9 @@ class SQLAlchemyStore(BaseStore):
                     tasks.append(self.rebuild_task(row.state))
                 except Exception:
                     task_id = row.id
-                    self.logger.exception(f"Unable to restore task '{task_id}'. Removing it...")
+                    cast("SchedulerType", self.scheduler).loggers[self.logger_name].exception(
+                        f"Unable to restore task '{task_id}'. Removing it..."
+                    )
                     failed_task_ids.append(task_id)
 
             if failed_task_ids:

--- a/asyncz/utils.py
+++ b/asyncz/utils.py
@@ -80,7 +80,8 @@ def to_timezone(value: Any) -> Optional[tzinfo]:
     Converts a value to timezone object.
     """
     if isinstance(value, str):
-        return ZoneInfo(value)
+        # python 3.8 typing issue
+        return cast(tzinfo, ZoneInfo(value))
     if isinstance(value, tzinfo):
         return value
     if value is not None:
@@ -164,7 +165,8 @@ def to_datetime(
         )
 
     if isinstance(tz, str):
-        tz = ZoneInfo(tz)
+        # python 3.8 typing issue
+        tz = cast(tzinfo, ZoneInfo(tz))
 
     return localize(_datetime, tz)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 services:
   redis:
     image: redis

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -6,6 +6,8 @@
 
 - Allow submitting paused tasks.
 - Allow changing in-place attributes of tasks when submitting with `add_task`.
+- Allow selecting logger (classical, loguru).
+- Allow naming schedulers with an extra logger name.
 
 ### Fixed
 
@@ -18,6 +20,7 @@
 - `pending_tasks` has now no more store alias in it.
 - `tzlocal` is now optional.
 - Tasks use the timezone of the scheduler for their triggers which require a timezone.
+- `loguru` is now optional.
 
 ## 0.10.1
 

--- a/docs/schedulers.md
+++ b/docs/schedulers.md
@@ -85,11 +85,30 @@ instantiation.
 
 #### Third option
 
-The third option is by starting the scheduler and use the `configure` method.
+The third option is by starting the scheduler and use the `setup` method.
 
 ```python
 {!> ../docs_src/schedulers/method3.py !}
 ```
+
+## Changing logger name and class
+
+`asyncz` uses a custom way of logging: it builds up a dictionary store with loggers of the standard logger interface.
+They are retrieved from schedulers via their alias name plus prefix.
+
+e.g. `asyncz.schedulers`, `asyncz.stores.default`, `asyncz.executors.default`
+
+Scheduler has an optional parameter named `logger_name`. If set the the schedulers logger becomes:
+
+`asyncz.schedulers.<name specified>`
+
+By default `asyncz` uses loguru as logger (when available) and falls back to classical logging.
+
+If this is not wished there are some methods:
+
+- setting either via global config or direct the value of `loggers_class` to `asyncz.schedulers.base:ClassicLogging` (or the class itself instead of the string) when creating a scheduler object
+- setting `asyncz.schedulers.base.default_loggers_class` to ClassicLogging (same file, only class is possible here)
+
 
 ## Starting and stopping the scheduler
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ classifiers = [
 ]
 dependencies = [
     "cryptography",
-    "loguru>=0.7.0,<0.8.0",
     "pydantic>=2.5.3,<3.0.0",
     'backports.zoneinfo;python_version<"3.9"',
 ]
@@ -70,8 +69,9 @@ dependencies = ["pre-commit>=2.17.0,<3.0.0", "ipdb", "types-tzlocal"]
 
 [project.optional-dependencies]
 localtime=["tzlocal"]
+loguru=["loguru>=0.7.0,<0.8.0"]
 testing = [
-    "asyncz[localtime]",
+    "asyncz[localtime,loguru]",
     "pymongo>=4.3.3,<5.0.0",
     "pytest>=7.1.3,<9.0.0",
     "pytest-cov >=2.12.0,<6.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import pytz
 
 from asyncz.schedulers.asyncio import AsyncIOScheduler
-from asyncz.schedulers.base import BaseScheduler
+from asyncz.schedulers.base import BaseScheduler, LoguruLogging
 from asyncz.tasks import Task
 
 
@@ -69,7 +69,8 @@ def task_defaults(timezone):
 @pytest.fixture(scope="function")
 def create_task(task_defaults, timezone):
     def create(**kwargs):
-        kwargs.setdefault("scheduler", Mock(BaseScheduler, timezone=timezone))
+        mock_scheduler = Mock(BaseScheduler, timezone=timezone, loggers=LoguruLogging())
+        kwargs.setdefault("scheduler", mock_scheduler)
         task_kwargs = task_defaults.copy()
         task_kwargs.update(kwargs)
         task_kwargs["trigger"] = AsyncIOScheduler().create_trigger(

--- a/tests/test_executors.py
+++ b/tests/test_executors.py
@@ -14,7 +14,7 @@ from asyncz.exceptions import MaximumInstancesError
 from asyncz.executors.asyncio import AsyncIOExecutor
 from asyncz.executors.base import run_coroutine_task, run_task
 from asyncz.schedulers.asyncio import AsyncIOScheduler
-from asyncz.schedulers.base import BaseScheduler
+from asyncz.schedulers.base import BaseScheduler, LoguruLogging
 from asyncz.tasks import Task
 
 
@@ -22,6 +22,7 @@ from asyncz.tasks import Task
 def scheduler_mocked(timezone):
     scheduler_ = Mock(BaseScheduler, timezone=timezone)
     scheduler_.create_lock = MagicMock()
+    scheduler_.loggers = LoguruLogging()
     return scheduler_
 
 
@@ -32,7 +33,7 @@ def executor(request, scheduler_mocked):
 
         executor = ThreadPoolExecutor()
     else:
-        from asyncz.executors.pool import ProcessPoolExecutor
+        from asyncz.executors.process_pool import ProcessPoolExecutor
 
         executor = ProcessPoolExecutor()
 
@@ -196,7 +197,6 @@ async def test_run_task_memory_leak_two():
         raise Exception("dummy")
 
     fake_task = Mock(Task, id="dummy", fn=fn, args=(), kwargs={}, mistrigger_grace_time=1)
-
     with patch("loguru.logger"):
         for _ in range(5):
             await run_coroutine_task(fake_task, "foo", [datetime.now(pytz.utc)], logger)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -16,6 +16,7 @@ from starlette.routing import Route
 from starlette.testclient import TestClient
 
 from asyncz.schedulers.asyncio import AsyncIOScheduler
+from asyncz.schedulers.base import ClassicLogging, LoguruLogging
 
 
 def get_starlette_app():
@@ -155,6 +156,14 @@ def get_esmerald_app2():
 
 
 @pytest.mark.parametrize(
+    "loggers_class_string,loggers_class",
+    [
+        ["asyncz.schedulers.base:ClassicLogging", ClassicLogging],
+        ["asyncz.schedulers.base:LoguruLogging", LoguruLogging],
+    ],
+    ids=["ClassicLogging", "LoguruLogging"],
+)
+@pytest.mark.parametrize(
     "get_app",
     [
         get_starlette_app,
@@ -166,8 +175,10 @@ def get_esmerald_app2():
         get_esmerald_app2,
     ],
 )
-def test_integrations(get_app):
+def test_integrations(get_app, loggers_class_string, loggers_class):
     app, scheduler = get_app()
+    scheduler.setup(loggers_class=loggers_class_string)
+    assert isinstance(scheduler.loggers, loggers_class)
     dummy_job_called = 0
     async_dummy_job_called = 0
 

--- a/tests/test_schedulers.py
+++ b/tests/test_schedulers.py
@@ -36,7 +36,7 @@ from asyncz.exceptions import (
 )
 from asyncz.executors.base import BaseExecutor
 from asyncz.executors.debug import DebugExecutor
-from asyncz.schedulers.base import BaseScheduler
+from asyncz.schedulers.base import BaseScheduler, ClassicLogging
 from asyncz.stores.base import BaseStore
 from asyncz.stores.memory import MemoryStore
 from asyncz.tasks import Task
@@ -204,6 +204,57 @@ class TestBaseScheduler:
                 },
             }
         )
+
+    def test_scheduler_change_logger_direct_class(self):
+        """
+        Test scheduler is picking up the right loggers class
+        """
+        scheduler = DummyScheduler(loggers_class=ClassicLogging)
+        scheduler.start(paused=True)
+        assert isinstance(scheduler.loggers, ClassicLogging)
+        assert scheduler.logger_name == "asyncz.schedulers"
+
+    def test_scheduler_change_logger_class_path(self):
+        """
+        Test scheduler is picking up the right loggers class
+        """
+        scheduler = DummyScheduler(loggers_class="asyncz.schedulers.base:ClassicLogging")
+        scheduler.start(paused=True)
+        assert isinstance(scheduler.loggers, ClassicLogging)
+        assert scheduler.logger_name == "asyncz.schedulers"
+
+    def test_scheduler_change_logger_config(self):
+        """
+        Test scheduler is picking up the right loggers class
+        """
+        scheduler = DummyScheduler(
+            global_config={"asyncz.loggers_class": "asyncz.schedulers.base:ClassicLogging"}
+        )
+        scheduler.start(paused=True)
+        assert isinstance(scheduler.loggers, ClassicLogging)
+        assert scheduler.logger_name == "asyncz.schedulers"
+
+    def test_scheduler_change_logger_name(self):
+        """
+        Test scheduler is picking up the right logger name for loggers
+        """
+        scheduler = DummyScheduler(
+            global_config={"asyncz.loggers_class": "asyncz.schedulers.base:ClassicLogging"},
+            logger_name="test",
+        )
+        scheduler.start(paused=True)
+        assert isinstance(scheduler.loggers, ClassicLogging)
+        assert scheduler.logger_name == "asyncz.schedulers.test"
+
+    @patch("asyncz.schedulers.base.default_loggers_class", side_effect=ClassicLogging)
+    def test_scheduler_change_logger_change_default(self, patched):
+        """
+        Test scheduler is picking up the right loggers class
+        """
+        scheduler = DummyScheduler()
+        scheduler.start(paused=True)
+        assert isinstance(scheduler.loggers, ClassicLogging)
+        assert scheduler.logger_name == "asyncz.schedulers"
 
     @pytest.mark.parametrize("method", [BaseScheduler.setup, BaseScheduler.start])
     def test_scheduler_already_running(self, method, scheduler):

--- a/tests/test_stores.py
+++ b/tests/test_stores.py
@@ -99,6 +99,7 @@ def create_add_task(timezone, create_task):
             None if paused else task.trigger.get_next_trigger_time(timezone, None, run_at)
         )
         if store:
+            store.start(task.scheduler, "default")
             store.add_task(task)
         return task
 


### PR DESCRIPTION
Changes:
- make loguru optional, fallback to normal logging
- make normal logging selectable by overwriting either per scheduler or per default_loggers_class in asyncz.schedulers.base
- splitout process_pool from pool and pass a special logger
- provide tests
- update release notes and docs