### PR TITLE
Shapes: Async shapes validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Documentation: [https://asyncz.dymmond.com](https://asyncz.dymmond.com)
 - Async runtimes: `AsyncIOScheduler` for regular async applications and `NativeAsyncIOScheduler` for environments that already own the event loop.
 - Scheduling primitives: `date`, `interval`, `cron`, `and`, `or`, and `shutdown` triggers.
 - Durable stores: `memory`, `file`, `mongodb`, `redis`, and `sqlalchemy`.
+- Asyncz Shapes: validator-agnostic scheduler representation with Pydantic defaults and optional dataclass, attrs, msgspec, or trusted Python values.
 - Executor choices: asyncio event loop execution, thread pools, process pools, and direct debug execution.
 - Safe task control for operators: stable task ids, manual Run now, pause, resume, remove, inspect, preview, and update workflows.
 - Scheduler inspection APIs: process identity, lifecycle timing, task counts, stores, executors, instances visible in the current process, and upcoming run previews.
@@ -65,6 +66,8 @@ Useful extras:
 ```bash
 pip install "asyncz[dashboard]"
 pip install "asyncz[localtime]"
+pip install "asyncz[attrs]"
+pip install "asyncz[msgspec]"
 ```
 
 ## Quick start
@@ -147,6 +150,7 @@ Asyncz is built around four main component types:
 
 - [Schedulers](https://asyncz.dymmond.com/schedulers/)
 - [Triggers](https://asyncz.dymmond.com/triggers/)
+- [Shapes](https://asyncz.dymmond.com/shapes/)
 - [Stores](https://asyncz.dymmond.com/stores/)
 - [Executors](https://asyncz.dymmond.com/executors/)
 

--- a/asyncz/__init__.py
+++ b/asyncz/__init__.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 from .monkay import create_monkay
 from .schedulers import AsyncIOScheduler as Asyncz
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"
 
 if TYPE_CHECKING:
     from .conf import settings

--- a/asyncz/__init__.py
+++ b/asyncz/__init__.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 
 from .monkay import create_monkay
+from .schedulers import AsyncIOScheduler as Asyncz
 
 __version__ = "0.16.0"
 
@@ -10,6 +11,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "Asyncz",
     "Settings",
     "settings",
 ]

--- a/asyncz/schedulers/base.py
+++ b/asyncz/schedulers/base.py
@@ -51,6 +51,7 @@ from asyncz.schedulers import defaults
 from asyncz.schedulers.datastructures import TaskDefaultStruct
 from asyncz.schedulers.inspection import SchedulerInfo, SchedulerInstanceInfo
 from asyncz.schedulers.types import LoggersType, SchedulerType
+from asyncz.shapes import ShapeContext, resolve_shape
 from asyncz.stores.memory import MemoryStore
 from asyncz.stores.types import StoreType
 from asyncz.tasks.inspection import TaskInfo, TaskRunPreview
@@ -115,6 +116,7 @@ class BaseScheduler(SchedulerType):
         self.started_at: datetime | None = None
         self.last_seen_at: datetime | None = None
         self.heartbeat_stale_after: float = 30.0
+        self.shape = resolve_shape()
 
         self.ref_counter: int = 0
         self.ref_lock: Lock = Lock()
@@ -620,7 +622,19 @@ class BaseScheduler(SchedulerType):
         if task_kwargs["trigger"].allow_mistrigger_by_default:
             # we want to be able, to just use add_task, and the task is scheduled
             task_kwargs.setdefault("mistrigger_grace_time", None)
-        for key, value in self.task_defaults.model_dump(exclude_none=True).items():
+        task_default_context = ShapeContext(
+            entity="task_defaults",
+            operation="dump",
+            scheduler_identity=self.identity,
+        )
+        task_defaults = self.shape.dump(
+            self.task_defaults,
+            context=task_default_context,
+            exclude_none=True,
+        )
+        if not isinstance(task_defaults, Mapping):
+            raise TypeError("Task defaults must dump to a mapping.")
+        for key, value in task_defaults.items():
             task_kwargs.setdefault(key, value)
 
         task = Task(**task_kwargs)
@@ -644,7 +658,17 @@ class BaseScheduler(SchedulerType):
         """
         if isinstance(task_id, TaskType):
             assert task_id.id, "Cannot update a decorator type Task"
-            new_updates = task_id.model_dump()
+            new_updates = self.shape.dump(
+                task_id,
+                context=ShapeContext(
+                    entity="task",
+                    operation="dump",
+                    scheduler_identity=self.identity,
+                ),
+            )
+            if not isinstance(new_updates, Mapping):
+                raise TypeError("Task snapshots must dump to a mapping.")
+            new_updates = dict(new_updates)
             new_updates.update(**updates)
             task_id = task_id.id
         else:
@@ -1229,12 +1253,24 @@ class BaseScheduler(SchedulerType):
         self.started_at = None
         self.last_seen_at = None
         self.heartbeat_stale_after = float(config.pop("heartbeat_stale_after", 30))
+        self.shape = resolve_shape(config.pop("shape", self.shape))
         self.timezone = to_timezone_with_fallback(config.pop("timezone", None))
         self.lock_path = str(config.pop("lock_path", "") or "")
         self.store_retry_interval = float(config.pop("store_retry_interval", 10))
         self.startup_delay = float(config.pop("startup_delay", 0 if not self.lock_path else 1))
 
-        self.task_defaults = TaskDefaultStruct(**(config.get("task_defaults", None) or {}))
+        task_defaults_value = config.get("task_defaults", None) or {}
+        task_defaults_data = self.shape.dump(
+            task_defaults_value,
+            context=ShapeContext(
+                entity="task_defaults",
+                operation="load",
+                scheduler_identity=self.identity,
+            ),
+        )
+        if not isinstance(task_defaults_data, Mapping):
+            raise TypeError("Configured task_defaults must resolve to a mapping.")
+        self.task_defaults = TaskDefaultStruct(**task_defaults_data)
         loggers_class: type[LoggersType] = (
             maybe_ref(config.pop("loggers_class", None)) or default_loggers_class
         )

--- a/asyncz/schedulers/datastructures.py
+++ b/asyncz/schedulers/datastructures.py
@@ -1,9 +1,49 @@
-from typing import Optional  # noqa: F401
-
-from pydantic import BaseModel
+from typing import Optional
 
 from asyncz.tasks.types import TaskDefaultsType
 
 
-class TaskDefaultStruct(BaseModel, TaskDefaultsType):
-    pass
+def _coerce_bool(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "t", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "f", "no", "n", "off"}:
+            return False
+    return bool(value)
+
+
+class TaskDefaultStruct(TaskDefaultsType):
+    """
+    Asyncz-owned task defaults with Pydantic-style dump compatibility.
+
+    The scheduler owns these defaults. Shapes may provide the incoming
+    representation, but this object remains the canonical scheduler contract.
+    """
+
+    __slots__ = ("coalesce", "max_instances", "mistrigger_grace_time")
+
+    def __init__(
+        self,
+        mistrigger_grace_time: Optional[float] = 1,
+        coalesce: bool = True,
+        max_instances: int = 1,
+        **extra: object,
+    ) -> None:
+        self.mistrigger_grace_time = (
+            None if mistrigger_grace_time is None else float(mistrigger_grace_time)
+        )
+        self.coalesce = _coerce_bool(coalesce)
+        self.max_instances = int(max_instances)
+
+    def model_dump(self, *, exclude_none: bool = False, **kwargs: object) -> dict[str, object]:
+        data: dict[str, object] = {
+            "mistrigger_grace_time": self.mistrigger_grace_time,
+            "coalesce": self.coalesce,
+            "max_instances": self.max_instances,
+        }
+        if exclude_none:
+            return {key: value for key, value in data.items() if value is not None}
+        return data

--- a/asyncz/schedulers/datastructures.py
+++ b/asyncz/schedulers/datastructures.py
@@ -4,6 +4,14 @@ from asyncz.tasks.types import TaskDefaultsType
 
 
 def _coerce_bool(value: object) -> bool:
+    """
+    Coerce configuration values into booleans using Asyncz's legacy rules.
+
+    Pydantic previously handled common string booleans for task defaults. Keeping
+    the coercion here makes the scheduler-owned defaults preserve that behavior
+    without making Pydantic the owner of the defaults object.
+    """
+
     if isinstance(value, bool):
         return value
     if isinstance(value, str):
@@ -32,6 +40,14 @@ class TaskDefaultStruct(TaskDefaultsType):
         max_instances: int = 1,
         **extra: object,
     ) -> None:
+        """
+        Build scheduler-owned task defaults from user configuration.
+
+        The constructor accepts the same core fields as the previous Pydantic
+        model and ignores unrelated extras so configuration callers keep the
+        existing tolerant behavior.
+        """
+
         self.mistrigger_grace_time = (
             None if mistrigger_grace_time is None else float(mistrigger_grace_time)
         )
@@ -39,6 +55,14 @@ class TaskDefaultStruct(TaskDefaultsType):
         self.max_instances = int(max_instances)
 
     def model_dump(self, *, exclude_none: bool = False, **kwargs: object) -> dict[str, object]:
+        """
+        Return a Pydantic-compatible mapping of task defaults.
+
+        Existing callers and tests use `model_dump()`. Keeping this projection
+        avoids forcing downstream code to change while Asyncz moves ownership of
+        the defaults away from Pydantic.
+        """
+
         data: dict[str, object] = {
             "mistrigger_grace_time": self.mistrigger_grace_time,
             "coalesce": self.coalesce,

--- a/asyncz/shapes/__init__.py
+++ b/asyncz/shapes/__init__.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from asyncz.shapes.base import Shape, ShapeContext, ShapeField
+from asyncz.shapes.builtins import (
+    AnyShape,
+    AttrsShape,
+    DataclassShape,
+    MsgspecShape,
+    PydanticShape,
+)
+from asyncz.shapes.errors import (
+    ShapeCapabilityError,
+    ShapeCompatibilityError,
+    ShapeDependencyError,
+    ShapeDeserializationError,
+    ShapeError,
+    ShapeMigrationError,
+    ShapeNotFoundError,
+    ShapeRegistrationError,
+    ShapeSerializationError,
+    ShapeValidationError,
+)
+from asyncz.shapes.registry import ShapeRegistry, register_shape, resolve_shape, shapes
+
+ShapeRegistry.register("pydantic", PydanticShape, replace=True)
+ShapeRegistry.register("msgspec", MsgspecShape, replace=True)
+ShapeRegistry.register("attrs", AttrsShape, replace=True)
+ShapeRegistry.register("dataclass", DataclassShape, replace=True)
+ShapeRegistry.register("any", AnyShape, replace=True)
+
+__all__ = [
+    "AnyShape",
+    "AttrsShape",
+    "DataclassShape",
+    "MsgspecShape",
+    "PydanticShape",
+    "Shape",
+    "ShapeCapabilityError",
+    "ShapeCompatibilityError",
+    "ShapeContext",
+    "ShapeDependencyError",
+    "ShapeDeserializationError",
+    "ShapeError",
+    "ShapeField",
+    "ShapeMigrationError",
+    "ShapeNotFoundError",
+    "ShapeRegistrationError",
+    "ShapeRegistry",
+    "ShapeSerializationError",
+    "ShapeValidationError",
+    "register_shape",
+    "resolve_shape",
+    "shapes",
+]

--- a/asyncz/shapes/base.py
+++ b/asyncz/shapes/base.py
@@ -33,6 +33,14 @@ class ShapeContext:
 
 @dataclass(frozen=True)
 class ShapeField:
+    """
+    Validator-independent description of one model field.
+
+    Shape implementations use this small projection when Asyncz or user tooling
+    needs field names, annotations, defaults, or requiredness without importing
+    validator-specific field classes.
+    """
+
     name: str
     annotation: Any = Any
     default: Any = None
@@ -42,6 +50,10 @@ class ShapeField:
 def dump_plain(value: Any, *, exclude_none: bool = False) -> Any:
     """
     Dump common Python objects into scheduler-safe builtins when possible.
+
+    This helper is deliberately conservative. It handles common structured
+    objects without becoming a general serialization framework or taking over
+    scheduler semantics from the selected Shape.
     """
 
     if hasattr(value, "model_dump"):
@@ -97,16 +109,40 @@ class Shape:
     version: ClassVar[int] = 1
 
     def supports(self, value_or_type: Any) -> bool:
+        """
+        Return whether this Shape recognizes a value or model type.
+
+        Automatic support checks are advisory and must not make persistence
+        nondeterministic. Scheduler configuration still chooses the active Shape
+        explicitly.
+        """
+
         return False
 
     def validate(
         self, model_type: type[Any], value: Any, *, context: ShapeContext | None = None
     ) -> Any:
+        """
+        Validate a value against the requested model type.
+
+        The base implementation delegates to construction because Asyncz only
+        needs one canonical value after validation. Specific Shapes may override
+        this when their library distinguishes validation from construction.
+        """
+
         return self.construct(model_type, value, context=context)
 
     def construct(
         self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
     ) -> Any:
+        """
+        Construct a scheduler-facing object from a mapping or existing instance.
+
+        The default behavior is intentionally small and Pythonic. Library-specific
+        validation, aliases, converters, and error translation belong in concrete
+        Shape implementations.
+        """
+
         if isinstance(values, model_type):
             return values
         if isinstance(values, Mapping):
@@ -128,6 +164,14 @@ class Shape:
         context: ShapeContext | None = None,
         exclude_none: bool = False,
     ) -> Any:
+        """
+        Convert a value into a representation suitable for Asyncz boundaries.
+
+        Shapes use this operation for configuration, persistence payloads, and
+        presentation projections. The operation must not change scheduling
+        decisions or mutate scheduler runtime state.
+        """
+
         try:
             return dump_plain(value, exclude_none=exclude_none)
         except Exception as exc:
@@ -136,6 +180,14 @@ class Shape:
     def load(
         self, model_type: type[Any], value: Any, *, context: ShapeContext | None = None
     ) -> Any:
+        """
+        Restore a model instance from a previously dumped representation.
+
+        The base implementation routes through construction and translates
+        validation failures into restoration failures for clearer persistence
+        diagnostics.
+        """
+
         try:
             return self.construct(model_type, value, context=context)
         except ShapeValidationError as exc:
@@ -144,7 +196,22 @@ class Shape:
     def fields(
         self, model_type: type[Any], *, context: ShapeContext | None = None
     ) -> tuple[ShapeField, ...]:
+        """
+        Return validator-independent field metadata for a model type.
+
+        Field inspection is optional because not every supported representation
+        library exposes stable runtime field metadata.
+        """
+
         raise ShapeCapabilityError(f'Shape "{self.name}" does not expose field inspection.')
 
     def schema(self, model_type: type[Any], *, context: ShapeContext | None = None) -> Any:
+        """
+        Return a schema representation for a model type when available.
+
+        Schema generation is intentionally optional and Shape-specific. Callers
+        must handle `ShapeCapabilityError` when the selected library cannot
+        produce a meaningful schema.
+        """
+
         raise ShapeCapabilityError(f'Shape "{self.name}" does not expose schema generation.')

--- a/asyncz/shapes/base.py
+++ b/asyncz/shapes/base.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from inspect import isclass
+from typing import Any, ClassVar
+
+from asyncz.shapes.errors import (
+    ShapeCapabilityError,
+    ShapeDeserializationError,
+    ShapeSerializationError,
+    ShapeValidationError,
+)
+
+
+@dataclass(frozen=True)
+class ShapeContext:
+    """
+    Scheduler-owned context for representation operations.
+
+    Shapes receive only representation metadata, not scheduler internals. This keeps
+    validation and serialization separate from task execution and scheduling decisions.
+    """
+
+    entity: str
+    operation: str
+    scheduler_identity: str | None = None
+    strict: bool | None = None
+    schema_version: int | None = None
+    mode: str | None = None
+
+
+@dataclass(frozen=True)
+class ShapeField:
+    name: str
+    annotation: Any = Any
+    default: Any = None
+    required: bool = True
+
+
+def dump_plain(value: Any, *, exclude_none: bool = False) -> Any:
+    """
+    Dump common Python objects into scheduler-safe builtins when possible.
+    """
+
+    if hasattr(value, "model_dump"):
+        return value.model_dump(exclude_none=exclude_none)
+
+    if dataclasses.is_dataclass(value) and not isclass(value):
+        return {
+            field.name: dump_plain(getattr(value, field.name), exclude_none=exclude_none)
+            for field in dataclasses.fields(value)
+            if not exclude_none or getattr(value, field.name) is not None
+        }
+
+    try:
+        import attr
+    except ImportError:
+        attr = None  # type: ignore[assignment]
+
+    if attr is not None and attr.has(value.__class__):
+        return {
+            key: dump_plain(item, exclude_none=exclude_none)
+            for key, item in attr.asdict(value, recurse=False).items()
+            if not exclude_none or item is not None
+        }
+
+    if isinstance(value, Mapping):
+        return {
+            key: dump_plain(item, exclude_none=exclude_none)
+            for key, item in value.items()
+            if not exclude_none or item is not None
+        }
+
+    if isinstance(value, tuple):
+        return tuple(dump_plain(item, exclude_none=exclude_none) for item in value)
+
+    if isinstance(value, list):
+        return [dump_plain(item, exclude_none=exclude_none) for item in value]
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [dump_plain(item, exclude_none=exclude_none) for item in value]
+
+    return value
+
+
+class Shape:
+    """
+    Asyncz-owned contract for validation and representation mechanics.
+
+    A Shape may validate, construct, dump, restore, inspect, and optionally expose
+    schemas for scheduler-facing values. It must not own scheduling behavior.
+    """
+
+    name: ClassVar[str] = "shape"
+    version: ClassVar[int] = 1
+
+    def supports(self, value_or_type: Any) -> bool:
+        return False
+
+    def validate(
+        self, model_type: type[Any], value: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        return self.construct(model_type, value, context=context)
+
+    def construct(
+        self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        if isinstance(values, model_type):
+            return values
+        if isinstance(values, Mapping):
+            try:
+                return model_type(**values)
+            except Exception as exc:
+                raise ShapeValidationError(
+                    f'Shape "{self.name}" could not construct {model_type.__name__}.'
+                ) from exc
+        raise ShapeValidationError(
+            f'Shape "{self.name}" expected a mapping or {model_type.__name__} instance.'
+        )
+
+    def dump(
+        self,
+        value: Any,
+        *,
+        mode: str | None = None,
+        context: ShapeContext | None = None,
+        exclude_none: bool = False,
+    ) -> Any:
+        try:
+            return dump_plain(value, exclude_none=exclude_none)
+        except Exception as exc:
+            raise ShapeSerializationError(f'Shape "{self.name}" could not dump value.') from exc
+
+    def load(
+        self, model_type: type[Any], value: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        try:
+            return self.construct(model_type, value, context=context)
+        except ShapeValidationError as exc:
+            raise ShapeDeserializationError(str(exc)) from exc
+
+    def fields(
+        self, model_type: type[Any], *, context: ShapeContext | None = None
+    ) -> tuple[ShapeField, ...]:
+        raise ShapeCapabilityError(f'Shape "{self.name}" does not expose field inspection.')
+
+    def schema(self, model_type: type[Any], *, context: ShapeContext | None = None) -> Any:
+        raise ShapeCapabilityError(f'Shape "{self.name}" does not expose schema generation.')

--- a/asyncz/shapes/builtins.py
+++ b/asyncz/shapes/builtins.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from inspect import isclass
+from typing import Any, get_type_hints
+
+from asyncz.shapes.base import Shape, ShapeContext, ShapeField, dump_plain
+from asyncz.shapes.errors import (
+    ShapeCapabilityError,
+    ShapeDependencyError,
+    ShapeSerializationError,
+    ShapeValidationError,
+)
+
+
+class PydanticShape(Shape):
+    name = "pydantic"
+
+    def supports(self, value_or_type: Any) -> bool:
+        try:
+            from pydantic import BaseModel
+        except ImportError:
+            return False
+
+        candidate = value_or_type if isclass(value_or_type) else value_or_type.__class__
+        return isclass(candidate) and issubclass(candidate, BaseModel)
+
+    def construct(
+        self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        if isinstance(values, model_type):
+            return values
+        if self.supports(model_type):
+            try:
+                return model_type.model_validate(values)
+            except Exception as exc:
+                raise ShapeValidationError(
+                    f'Shape "{self.name}" could not validate {model_type.__name__}.'
+                ) from exc
+        return super().construct(model_type, values, context=context)
+
+    def dump(
+        self,
+        value: Any,
+        *,
+        mode: str | None = None,
+        context: ShapeContext | None = None,
+        exclude_none: bool = False,
+    ) -> Any:
+        if hasattr(value, "model_dump"):
+            try:
+                return value.model_dump(mode=mode or "python", exclude_none=exclude_none)
+            except TypeError:
+                return value.model_dump(exclude_none=exclude_none)
+            except Exception as exc:
+                raise ShapeSerializationError(
+                    f'Shape "{self.name}" could not dump {value.__class__.__name__}.'
+                ) from exc
+        return super().dump(value, mode=mode, context=context, exclude_none=exclude_none)
+
+    def fields(
+        self, model_type: type[Any], *, context: ShapeContext | None = None
+    ) -> tuple[ShapeField, ...]:
+        if self.supports(model_type):
+            result: list[ShapeField] = []
+            for name, field in model_type.model_fields.items():
+                required = field.is_required()
+                default = None if required else field.default
+                result.append(
+                    ShapeField(
+                        name=name,
+                        annotation=field.annotation,
+                        default=default,
+                        required=required,
+                    )
+                )
+            return tuple(result)
+        return super().fields(model_type, context=context)
+
+    def schema(self, model_type: type[Any], *, context: ShapeContext | None = None) -> Any:
+        if self.supports(model_type) and hasattr(model_type, "model_json_schema"):
+            return model_type.model_json_schema()
+        return super().schema(model_type, context=context)
+
+
+class DataclassShape(Shape):
+    name = "dataclass"
+
+    def supports(self, value_or_type: Any) -> bool:
+        return dataclasses.is_dataclass(value_or_type)
+
+    def construct(
+        self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        if dataclasses.is_dataclass(model_type):
+            if isinstance(values, model_type):
+                return values
+            if isinstance(values, Mapping):
+                try:
+                    return model_type(**values)
+                except Exception as exc:
+                    raise ShapeValidationError(
+                        f'Shape "{self.name}" could not construct {model_type.__name__}.'
+                    ) from exc
+        return super().construct(model_type, values, context=context)
+
+    def fields(
+        self, model_type: type[Any], *, context: ShapeContext | None = None
+    ) -> tuple[ShapeField, ...]:
+        if not dataclasses.is_dataclass(model_type):
+            return super().fields(model_type, context=context)
+        hints = get_type_hints(model_type)
+        result: list[ShapeField] = []
+        for field in dataclasses.fields(model_type):
+            required = (
+                field.default is dataclasses.MISSING
+                and field.default_factory is dataclasses.MISSING
+            )
+            default = None if required else field.default
+            result.append(
+                ShapeField(
+                    name=field.name,
+                    annotation=hints.get(field.name, Any),
+                    default=default,
+                    required=required,
+                )
+            )
+        return tuple(result)
+
+
+class AttrsShape(Shape):
+    name = "attrs"
+
+    def _attrs(self) -> Any:
+        try:
+            import attr
+        except ImportError as exc:
+            raise ShapeDependencyError(self.name, "attrs", "attrs") from exc
+        return attr
+
+    def supports(self, value_or_type: Any) -> bool:
+        try:
+            attr = self._attrs()
+        except ShapeDependencyError:
+            return False
+        candidate = value_or_type if isclass(value_or_type) else value_or_type.__class__
+        return attr.has(candidate)
+
+    def construct(
+        self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        attr = self._attrs()
+        if attr.has(model_type):
+            if isinstance(values, model_type):
+                return values
+            if isinstance(values, Mapping):
+                try:
+                    return model_type(**values)
+                except Exception as exc:
+                    raise ShapeValidationError(
+                        f'Shape "{self.name}" could not construct {model_type.__name__}.'
+                    ) from exc
+        return super().construct(model_type, values, context=context)
+
+    def dump(
+        self,
+        value: Any,
+        *,
+        mode: str | None = None,
+        context: ShapeContext | None = None,
+        exclude_none: bool = False,
+    ) -> Any:
+        attr = self._attrs()
+        if attr.has(value.__class__):
+            return {
+                key: dump_plain(item, exclude_none=exclude_none)
+                for key, item in attr.asdict(value, recurse=False).items()
+                if not exclude_none or item is not None
+            }
+        return super().dump(value, mode=mode, context=context, exclude_none=exclude_none)
+
+    def fields(
+        self, model_type: type[Any], *, context: ShapeContext | None = None
+    ) -> tuple[ShapeField, ...]:
+        attr = self._attrs()
+        if not attr.has(model_type):
+            return super().fields(model_type, context=context)
+        return tuple(
+            ShapeField(
+                name=field.name,
+                annotation=field.type,
+                default=None if field.default is attr.NOTHING else field.default,
+                required=field.default is attr.NOTHING,
+            )
+            for field in attr.fields(model_type)
+        )
+
+
+class MsgspecShape(Shape):
+    name = "msgspec"
+
+    def _msgspec(self) -> Any:
+        try:
+            import msgspec
+        except ImportError as exc:
+            raise ShapeDependencyError(self.name, "msgspec", "msgspec") from exc
+        return msgspec
+
+    def supports(self, value_or_type: Any) -> bool:
+        try:
+            msgspec = self._msgspec()
+        except ShapeDependencyError:
+            return False
+        candidate = value_or_type if isclass(value_or_type) else value_or_type.__class__
+        return isclass(candidate) and issubclass(candidate, msgspec.Struct)
+
+    def construct(
+        self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        msgspec = self._msgspec()
+        if self.supports(model_type):
+            if isinstance(values, model_type):
+                return values
+            try:
+                return msgspec.convert(values, type=model_type)
+            except Exception as exc:
+                raise ShapeValidationError(
+                    f'Shape "{self.name}" could not convert {model_type.__name__}.'
+                ) from exc
+        return super().construct(model_type, values, context=context)
+
+    def dump(
+        self,
+        value: Any,
+        *,
+        mode: str | None = None,
+        context: ShapeContext | None = None,
+        exclude_none: bool = False,
+    ) -> Any:
+        msgspec = self._msgspec()
+        if self.supports(value):
+            try:
+                return msgspec.to_builtins(value)
+            except Exception as exc:
+                raise ShapeSerializationError(
+                    f'Shape "{self.name}" could not dump {value.__class__.__name__}.'
+                ) from exc
+        return super().dump(value, mode=mode, context=context, exclude_none=exclude_none)
+
+    def fields(
+        self, model_type: type[Any], *, context: ShapeContext | None = None
+    ) -> tuple[ShapeField, ...]:
+        msgspec = self._msgspec()
+        if not self.supports(model_type):
+            return super().fields(model_type, context=context)
+        return tuple(
+            ShapeField(
+                name=field.name,
+                annotation=field.type,
+                default=field.default,
+                required=field.required,
+            )
+            for field in msgspec.structs.fields(model_type)
+        )
+
+    def schema(self, model_type: type[Any], *, context: ShapeContext | None = None) -> Any:
+        msgspec = self._msgspec()
+        if not self.supports(model_type):
+            return super().schema(model_type, context=context)
+        return msgspec.json.schema(model_type)
+
+
+class AnyShape(Shape):
+    name = "any"
+
+    def supports(self, value_or_type: Any) -> bool:
+        return True
+
+    def construct(
+        self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        if model_type in (Any, object):
+            return values
+        if isinstance(values, model_type):
+            return values
+        if isinstance(values, Mapping):
+            try:
+                return model_type(**values)
+            except Exception as exc:
+                raise ShapeValidationError(
+                    f'Shape "{self.name}" could not construct {model_type.__name__}.'
+                ) from exc
+        try:
+            return model_type(values)
+        except Exception as exc:
+            raise ShapeValidationError(
+                f'Shape "{self.name}" could not construct {model_type.__name__}.'
+            ) from exc
+
+    def schema(self, model_type: type[Any], *, context: ShapeContext | None = None) -> Any:
+        raise ShapeCapabilityError('Shape "any" intentionally does not expose schemas.')

--- a/asyncz/shapes/builtins.py
+++ b/asyncz/shapes/builtins.py
@@ -15,9 +15,25 @@ from asyncz.shapes.errors import (
 
 
 class PydanticShape(Shape):
+    """
+    Default Shape implementation backed by Pydantic public APIs.
+
+    This Shape preserves the current default Asyncz experience while moving
+    Pydantic-specific validation, dumping, field inspection, and schema
+    generation behind the Asyncz Shape contract.
+    """
+
     name = "pydantic"
 
     def supports(self, value_or_type: Any) -> bool:
+        """
+        Return whether the value or type is a Pydantic model.
+
+        Import failures return `False` so optional dependency checks can be
+        handled at explicit selection points rather than during incidental type
+        probing.
+        """
+
         try:
             from pydantic import BaseModel
         except ImportError:
@@ -29,6 +45,14 @@ class PydanticShape(Shape):
     def construct(
         self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
     ) -> Any:
+        """
+        Construct a model using Pydantic validation when applicable.
+
+        Pydantic's native validation error is retained as the exception cause so
+        callers still get the field-level detail they expect from the default
+        Shape.
+        """
+
         if isinstance(values, model_type):
             return values
         if self.supports(model_type):
@@ -48,6 +72,14 @@ class PydanticShape(Shape):
         context: ShapeContext | None = None,
         exclude_none: bool = False,
     ) -> Any:
+        """
+        Dump Pydantic models with `model_dump` and fall back to plain dumping.
+
+        The optional mode is passed to Pydantic when supported. Older compatible
+        surfaces that do not accept the mode parameter still work through the
+        fallback path.
+        """
+
         if hasattr(value, "model_dump"):
             try:
                 return value.model_dump(mode=mode or "python", exclude_none=exclude_none)
@@ -62,6 +94,14 @@ class PydanticShape(Shape):
     def fields(
         self, model_type: type[Any], *, context: ShapeContext | None = None
     ) -> tuple[ShapeField, ...]:
+        """
+        Expose Pydantic model field metadata as Asyncz Shape fields.
+
+        The returned field objects intentionally hide Pydantic internals so
+        scheduler and documentation code do not depend on validator-specific
+        field classes.
+        """
+
         if self.supports(model_type):
             result: list[ShapeField] = []
             for name, field in model_type.model_fields.items():
@@ -79,20 +119,51 @@ class PydanticShape(Shape):
         return super().fields(model_type, context=context)
 
     def schema(self, model_type: type[Any], *, context: ShapeContext | None = None) -> Any:
+        """
+        Return Pydantic's JSON schema for supported model types.
+
+        Schema generation stays optional at the Shape boundary because other
+        supported libraries may expose different schema capabilities.
+        """
+
         if self.supports(model_type) and hasattr(model_type, "model_json_schema"):
             return model_type.model_json_schema()
         return super().schema(model_type, context=context)
 
 
 class DataclassShape(Shape):
+    """
+    Shape implementation for standard-library dataclasses.
+
+    Dataclasses provide construction and field metadata, but they do not provide
+    Pydantic-equivalent runtime validation. This Shape therefore keeps its
+    behavior explicit and conservative.
+    """
+
     name = "dataclass"
 
     def supports(self, value_or_type: Any) -> bool:
+        """
+        Return whether the value or type is a dataclass.
+
+        The standard `dataclasses.is_dataclass` check supports both dataclass
+        classes and dataclass instances, which is exactly what scheduler
+        configuration needs.
+        """
+
         return dataclasses.is_dataclass(value_or_type)
 
     def construct(
         self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
     ) -> Any:
+        """
+        Construct a dataclass from a mapping or return an existing instance.
+
+        The constructor may run user-defined `__post_init__` logic, but this
+        Shape does not imply stronger validation than dataclasses actually
+        provide.
+        """
+
         if dataclasses.is_dataclass(model_type):
             if isinstance(values, model_type):
                 return values
@@ -108,6 +179,13 @@ class DataclassShape(Shape):
     def fields(
         self, model_type: type[Any], *, context: ShapeContext | None = None
     ) -> tuple[ShapeField, ...]:
+        """
+        Return dataclass field metadata as Asyncz Shape fields.
+
+        Type hints are resolved with `get_type_hints` where possible so callers
+        receive ordinary Python annotations rather than dataclass internals.
+        """
+
         if not dataclasses.is_dataclass(model_type):
             return super().fields(model_type, context=context)
         hints = get_type_hints(model_type)
@@ -130,9 +208,24 @@ class DataclassShape(Shape):
 
 
 class AttrsShape(Shape):
+    """
+    Shape implementation for attrs classes.
+
+    Attrs support remains optional. The Shape uses public attrs APIs for
+    construction, conversion, validators, defaults, and field inspection when
+    the dependency is installed.
+    """
+
     name = "attrs"
 
     def _attrs(self) -> Any:
+        """
+        Import attrs or raise an actionable Asyncz dependency error.
+
+        Keeping the import lazy lets the public registry expose the built-in
+        Shape name without requiring attrs for users who never select it.
+        """
+
         try:
             import attr
         except ImportError as exc:
@@ -140,6 +233,13 @@ class AttrsShape(Shape):
         return attr
 
     def supports(self, value_or_type: Any) -> bool:
+        """
+        Return whether attrs recognizes the value or type.
+
+        Missing optional dependencies make support probing return `False`
+        instead of leaking raw import errors during unrelated scheduler setup.
+        """
+
         try:
             attr = self._attrs()
         except ShapeDependencyError:
@@ -150,6 +250,13 @@ class AttrsShape(Shape):
     def construct(
         self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
     ) -> Any:
+        """
+        Construct an attrs class through its public initializer.
+
+        Attrs validators and converters remain owned by attrs and run through
+        the class constructor rather than being reimplemented by Asyncz.
+        """
+
         attr = self._attrs()
         if attr.has(model_type):
             if isinstance(values, model_type):
@@ -171,6 +278,13 @@ class AttrsShape(Shape):
         context: ShapeContext | None = None,
         exclude_none: bool = False,
     ) -> Any:
+        """
+        Dump attrs instances into plain mapping payloads.
+
+        The operation uses `attr.asdict` without recursive attrs conversion and
+        then lets Asyncz's plain dumper normalize nested values consistently.
+        """
+
         attr = self._attrs()
         if attr.has(value.__class__):
             return {
@@ -183,6 +297,13 @@ class AttrsShape(Shape):
     def fields(
         self, model_type: type[Any], *, context: ShapeContext | None = None
     ) -> tuple[ShapeField, ...]:
+        """
+        Return attrs field metadata as Asyncz Shape fields.
+
+        Requiredness is derived from attrs defaults so callers do not need to
+        understand attrs-specific sentinel values.
+        """
+
         attr = self._attrs()
         if not attr.has(model_type):
             return super().fields(model_type, context=context)
@@ -198,9 +319,23 @@ class AttrsShape(Shape):
 
 
 class MsgspecShape(Shape):
+    """
+    Shape implementation for `msgspec.Struct` models.
+
+    Msgspec support is optional and uses msgspec conversion, builtins dumping,
+    struct field inspection, and schema generation through public APIs.
+    """
+
     name = "msgspec"
 
     def _msgspec(self) -> Any:
+        """
+        Import msgspec or raise an actionable Asyncz dependency error.
+
+        Lazy importing allows Asyncz to expose the built-in registry entry while
+        keeping msgspec optional for default Pydantic installations.
+        """
+
         try:
             import msgspec
         except ImportError as exc:
@@ -208,6 +343,13 @@ class MsgspecShape(Shape):
         return msgspec
 
     def supports(self, value_or_type: Any) -> bool:
+        """
+        Return whether the value or type is a msgspec Struct.
+
+        Missing optional dependencies make support probing return `False`, while
+        explicit use still raises `ShapeDependencyError` with install guidance.
+        """
+
         try:
             msgspec = self._msgspec()
         except ShapeDependencyError:
@@ -218,6 +360,13 @@ class MsgspecShape(Shape):
     def construct(
         self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
     ) -> Any:
+        """
+        Construct msgspec Struct values through `msgspec.convert`.
+
+        The conversion path preserves msgspec's validation and conversion
+        behavior instead of translating Structs through another model system.
+        """
+
         msgspec = self._msgspec()
         if self.supports(model_type):
             if isinstance(values, model_type):
@@ -238,6 +387,13 @@ class MsgspecShape(Shape):
         context: ShapeContext | None = None,
         exclude_none: bool = False,
     ) -> Any:
+        """
+        Dump msgspec Struct instances into Python builtins.
+
+        The returned payload is suitable for Asyncz persistence envelopes and
+        transport boundaries that expect validator-independent values.
+        """
+
         msgspec = self._msgspec()
         if self.supports(value):
             try:
@@ -251,6 +407,14 @@ class MsgspecShape(Shape):
     def fields(
         self, model_type: type[Any], *, context: ShapeContext | None = None
     ) -> tuple[ShapeField, ...]:
+        """
+        Return msgspec Struct field metadata as Asyncz Shape fields.
+
+        The projection preserves the field names, annotations, defaults, and
+        requiredness that Asyncz tooling needs without exposing msgspec field
+        objects directly.
+        """
+
         msgspec = self._msgspec()
         if not self.supports(model_type):
             return super().fields(model_type, context=context)
@@ -265,6 +429,13 @@ class MsgspecShape(Shape):
         )
 
     def schema(self, model_type: type[Any], *, context: ShapeContext | None = None) -> Any:
+        """
+        Return msgspec's JSON schema for supported Struct models.
+
+        This capability is optional at the Shape contract level and only exists
+        when the msgspec dependency is installed.
+        """
+
         msgspec = self._msgspec()
         if not self.supports(model_type):
             return super().schema(model_type, context=context)
@@ -272,14 +443,37 @@ class MsgspecShape(Shape):
 
 
 class AnyShape(Shape):
+    """
+    Explicitly permissive Shape for trusted Python values.
+
+    This Shape is opt-in and intentionally does not imply strong validation or
+    schema guarantees. It is useful for controlled internal boundaries where the
+    application already owns validation.
+    """
+
     name = "any"
 
     def supports(self, value_or_type: Any) -> bool:
+        """
+        Return `True` for every value or type.
+
+        This broad support is safe only because `AnyShape` must be explicitly
+        selected and is never used as a silent fallback for unknown Shapes.
+        """
+
         return True
 
     def construct(
         self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
     ) -> Any:
+        """
+        Construct a Python object with minimal assumptions.
+
+        The method accepts existing instances, mapping-based constructors, and
+        single-value constructors. Failures are translated into Shape validation
+        errors without adding stronger guarantees than the model type provides.
+        """
+
         if model_type in (Any, object):
             return values
         if isinstance(values, model_type):
@@ -299,4 +493,11 @@ class AnyShape(Shape):
             ) from exc
 
     def schema(self, model_type: type[Any], *, context: ShapeContext | None = None) -> Any:
+        """
+        Reject schema generation for permissive values.
+
+        `AnyShape` cannot honestly describe the structure of arbitrary trusted
+        Python values, so schema access fails with an explicit capability error.
+        """
+
         raise ShapeCapabilityError('Shape "any" intentionally does not expose schemas.')

--- a/asyncz/shapes/errors.py
+++ b/asyncz/shapes/errors.py
@@ -6,40 +6,109 @@ from asyncz.exceptions import AsynczException
 class ShapeError(AsynczException):
     """
     Base error for Asyncz Shape operations.
+
+    Shape errors are raised at representation boundaries where Asyncz asks a
+    Shape to validate, dump, restore, inspect, or describe scheduler-facing
+    values.
     """
 
 
 class ShapeNotFoundError(ShapeError):
+    """
+    Raised when a configured Shape name is not registered.
+
+    This error is intentionally explicit so Asyncz never falls back to another
+    validator silently when persisted data or scheduler configuration names a
+    missing Shape.
+    """
+
     def __init__(self, name: str) -> None:
+        """
+        Build an unknown-Shape error for the provided registry name.
+
+        The registry name is preserved in the message because users normally
+        fix this by installing an optional dependency or registering a custom
+        Shape during process startup.
+        """
+
         super().__init__(f"Unknown Asyncz Shape '{name}'.")
 
 
 class ShapeRegistrationError(ShapeError):
-    pass
+    """
+    Raised when Shape registration would make resolution ambiguous.
+
+    Typical causes are empty names, non-Shape classes, or duplicate
+    registrations without an explicit replacement request.
+    """
 
 
 class ShapeCapabilityError(ShapeError):
-    pass
+    """
+    Raised when a Shape does not support an optional capability.
+
+    Optional operations such as schema generation and field inspection must fail
+    clearly instead of pretending every validation library can provide the same
+    information.
+    """
 
 
 class ShapeValidationError(ShapeError):
-    pass
+    """
+    Raised when a Shape cannot validate or construct a scheduler-facing value.
+
+    The original validator exception should remain attached as the cause when a
+    third-party library provides useful path or field-level detail.
+    """
 
 
 class ShapeSerializationError(ShapeError):
-    pass
+    """
+    Raised when a Shape cannot dump a value for transport or persistence.
+
+    Serialization failures are kept separate from validation failures so stores
+    and operators can tell whether input was invalid or an existing value could
+    not be represented safely.
+    """
 
 
 class ShapeDeserializationError(ShapeError):
-    pass
+    """
+    Raised when a Shape cannot restore a value from a stored representation.
+
+    This is used at persistence and transport boundaries where Asyncz has
+    already accepted a payload but cannot reconstruct the expected runtime
+    object.
+    """
 
 
 class ShapeCompatibilityError(ShapeError):
-    pass
+    """
+    Raised when a Shape cannot honor a requested compatibility contract.
+
+    Compatibility errors are reserved for cases where a representation is
+    structurally valid but cannot be used with the selected Asyncz or Shape
+    version.
+    """
 
 
 class ShapeDependencyError(ShapeError):
+    """
+    Raised when a built-in optional Shape is selected without its dependency.
+
+    The message includes the exact Asyncz extra so users get an actionable
+    installation command instead of a raw import error from the validator
+    library.
+    """
+
     def __init__(self, shape_name: str, dependency: str, extra: str) -> None:
+        """
+        Build a dependency error for an unavailable built-in Shape.
+
+        The `extra` argument is the Asyncz optional dependency group that should
+        be installed to make the selected Shape usable.
+        """
+
         super().__init__(
             f'The "{shape_name}" Asyncz Shape requires the optional "{dependency}" dependency. '
             f'Install it with: pip install "asyncz[{extra}]"'
@@ -47,4 +116,9 @@ class ShapeDependencyError(ShapeError):
 
 
 class ShapeMigrationError(ShapeError):
-    pass
+    """
+    Raised when persisted Shape data cannot be migrated or accepted.
+
+    Migration errors protect stores from silently loading unsupported entity
+    names, envelope versions, or record formats.
+    """

--- a/asyncz/shapes/errors.py
+++ b/asyncz/shapes/errors.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from asyncz.exceptions import AsynczException
+
+
+class ShapeError(AsynczException):
+    """
+    Base error for Asyncz Shape operations.
+    """
+
+
+class ShapeNotFoundError(ShapeError):
+    def __init__(self, name: str) -> None:
+        super().__init__(f"Unknown Asyncz Shape '{name}'.")
+
+
+class ShapeRegistrationError(ShapeError):
+    pass
+
+
+class ShapeCapabilityError(ShapeError):
+    pass
+
+
+class ShapeValidationError(ShapeError):
+    pass
+
+
+class ShapeSerializationError(ShapeError):
+    pass
+
+
+class ShapeDeserializationError(ShapeError):
+    pass
+
+
+class ShapeCompatibilityError(ShapeError):
+    pass
+
+
+class ShapeDependencyError(ShapeError):
+    def __init__(self, shape_name: str, dependency: str, extra: str) -> None:
+        super().__init__(
+            f'The "{shape_name}" Asyncz Shape requires the optional "{dependency}" dependency. '
+            f'Install it with: pip install "asyncz[{extra}]"'
+        )
+
+
+class ShapeMigrationError(ShapeError):
+    pass

--- a/asyncz/shapes/registry.py
+++ b/asyncz/shapes/registry.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from inspect import isclass
+from typing import Any
+
+from asyncz.shapes.base import Shape
+from asyncz.shapes.errors import ShapeError, ShapeNotFoundError, ShapeRegistrationError
+
+
+class ShapeRegistry:
+    """
+    Canonical process-local registry for Asyncz Shape implementations.
+    """
+
+    _registry: dict[str, type[Shape]] = {}
+
+    @classmethod
+    def register(cls, name: str, shape: type[Shape], *, replace: bool = False) -> type[Shape]:
+        if not isinstance(name, str) or not name:
+            raise ShapeRegistrationError("Shape names must be non-empty strings.")
+        if not isclass(shape) or not issubclass(shape, Shape):
+            raise ShapeRegistrationError("Only Shape classes can be registered.")
+        if name in cls._registry and not replace:
+            raise ShapeRegistrationError(f'An Asyncz Shape named "{name}" is already registered.')
+        cls._registry[name] = shape
+        return shape
+
+    @classmethod
+    def unregister(cls, name: str) -> None:
+        try:
+            del cls._registry[name]
+        except KeyError:
+            raise ShapeNotFoundError(name) from None
+
+    @classmethod
+    def get(cls, name: str) -> Shape:
+        try:
+            shape_class = cls._registry[name]
+        except KeyError:
+            raise ShapeNotFoundError(name) from None
+        return shape_class()
+
+    @classmethod
+    def available(cls) -> tuple[str, ...]:
+        return tuple(sorted(cls._registry))
+
+    @classmethod
+    def resolve(cls, shape: str | type[Shape] | Shape | None) -> Shape:
+        if shape is None:
+            return cls.get("pydantic")
+        if isinstance(shape, Shape):
+            return shape
+        if isinstance(shape, str):
+            return cls.get(shape)
+        if isclass(shape) and issubclass(shape, Shape):
+            return shape()
+        raise ShapeError(
+            "Shape must be None, a registered Shape name, a Shape class, or a Shape instance."
+        )
+
+
+shapes = ShapeRegistry()
+
+
+def resolve_shape(shape: str | type[Shape] | Shape | None = None) -> Shape:
+    return ShapeRegistry.resolve(shape)
+
+
+def register_shape(name: str, *, replace: bool = False) -> Any:
+    def decorator(shape: type[Shape]) -> type[Shape]:
+        return ShapeRegistry.register(name, shape, replace=replace)
+
+    return decorator

--- a/asyncz/shapes/registry.py
+++ b/asyncz/shapes/registry.py
@@ -10,12 +10,24 @@ from asyncz.shapes.errors import ShapeError, ShapeNotFoundError, ShapeRegistrati
 class ShapeRegistry:
     """
     Canonical process-local registry for Asyncz Shape implementations.
+
+    The registry is the single owner of Shape name resolution. Built-in and
+    custom Shapes use the same registration path so scheduler configuration and
+    persisted Shape identifiers remain deterministic.
     """
 
     _registry: dict[str, type[Shape]] = {}
 
     @classmethod
     def register(cls, name: str, shape: type[Shape], *, replace: bool = False) -> type[Shape]:
+        """
+        Register a Shape class under a stable name.
+
+        Duplicate names are rejected unless `replace` is explicit. This prevents
+        import order from silently changing how schedulers validate and restore
+        persisted data.
+        """
+
         if not isinstance(name, str) or not name:
             raise ShapeRegistrationError("Shape names must be non-empty strings.")
         if not isclass(shape) or not issubclass(shape, Shape):
@@ -27,6 +39,14 @@ class ShapeRegistry:
 
     @classmethod
     def unregister(cls, name: str) -> None:
+        """
+        Remove a Shape registration by name.
+
+        This is primarily useful in tests and controlled application startup
+        flows. Unknown names fail clearly so callers do not assume a cleanup
+        happened when it did not.
+        """
+
         try:
             del cls._registry[name]
         except KeyError:
@@ -34,6 +54,13 @@ class ShapeRegistry:
 
     @classmethod
     def get(cls, name: str) -> Shape:
+        """
+        Return a new Shape instance for a registered name.
+
+        Shape instances are created on demand so implementations can remain
+        stateless and scheduler-specific context stays outside the registry.
+        """
+
         try:
             shape_class = cls._registry[name]
         except KeyError:
@@ -42,10 +69,25 @@ class ShapeRegistry:
 
     @classmethod
     def available(cls) -> tuple[str, ...]:
+        """
+        Return registered Shape names in deterministic order.
+
+        Sorted output is useful for diagnostics, documentation, and tests where
+        import order should not affect visible registry state.
+        """
+
         return tuple(sorted(cls._registry))
 
     @classmethod
     def resolve(cls, shape: str | type[Shape] | Shape | None) -> Shape:
+        """
+        Resolve scheduler configuration into a Shape instance.
+
+        Accepted inputs are `None`, a registered name, a Shape class, or a Shape
+        instance. Anything else is rejected instead of being coerced into an
+        ambiguous representation boundary.
+        """
+
         if shape is None:
             return cls.get("pydantic")
         if isinstance(shape, Shape):
@@ -63,11 +105,32 @@ shapes = ShapeRegistry()
 
 
 def resolve_shape(shape: str | type[Shape] | Shape | None = None) -> Shape:
+    """
+    Resolve a Shape selection through the canonical registry.
+
+    This convenience function is the public helper used by schedulers, stores,
+    and applications that need the same deterministic resolution behavior.
+    """
+
     return ShapeRegistry.resolve(shape)
 
 
 def register_shape(name: str, *, replace: bool = False) -> Any:
+    """
+    Create a decorator for registering custom Shape classes.
+
+    The decorator keeps registration close to the custom class definition while
+    still using the same duplicate-name policy as direct registry calls.
+    """
+
     def decorator(shape: type[Shape]) -> type[Shape]:
+        """
+        Register the decorated Shape and return it unchanged.
+
+        Returning the original class preserves normal class usage, inheritance,
+        and testing patterns after registration.
+        """
+
         return ShapeRegistry.register(name, shape, replace=replace)
 
     return decorator

--- a/asyncz/stores/base.py
+++ b/asyncz/stores/base.py
@@ -6,8 +6,16 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from cryptography.hazmat.primitives.ciphers.aead import AESCCM
 
+from asyncz.datastructures import TaskState
 from asyncz.locks import FileLockProtected, NullLockProtected
+from asyncz.shapes import Shape, ShapeContext, ShapeError, resolve_shape
+from asyncz.shapes.errors import ShapeDeserializationError, ShapeMigrationError
 from asyncz.state import BaseStateExtra
+from asyncz.stores.persistence import (
+    TASK_STATE_ENTITY,
+    TASK_STATE_ENVELOPE_VERSION,
+    TaskStateEnvelope,
+)
 from asyncz.stores.types import StoreType
 
 if TYPE_CHECKING:
@@ -19,16 +27,32 @@ if TYPE_CHECKING:
 class BaseStore(BaseStateExtra, StoreType):
     """
     Base class for all task stores.
+
+    The store contract owns persistence location, encryption, and restoration
+    lifecycle. Shape integration is limited to representation conversion at the
+    task-state boundary.
     """
 
     def __init__(self, **kwargs: Any) -> None:
+        """
+        Initialize shared store state before scheduler startup.
+
+        Stores receive their final scheduler-selected Shape in `start()`, but a
+        default Shape is available immediately for tests and manually invoked
+        serialization helpers.
+        """
+
         super().__init__(**kwargs)
         self.scheduler: Optional[SchedulerType] = None
         self.encryption_key: Optional[AESCCM] = None
+        self.shape: Shape = resolve_shape()
 
     def create_lock(self) -> LockProtectedProtocol:
         """
         Creates a lock protector.
+
+        File locking is still owned by stores and scheduler configuration. Shapes
+        do not participate in concurrency or locking decisions.
         """
         if not self.scheduler or not self.scheduler.lock_path:
             return NullLockProtected()
@@ -42,11 +66,19 @@ class BaseStore(BaseStateExtra, StoreType):
         Args:
             scheduler: The scheduler that is starting this task store.
             alias: Alias of this task store as it was assigned to the scheduler.
+
+        The selected scheduler Shape is captured here so persisted task envelopes
+        include deterministic Shape identity for future restoration.
         """
         self.scheduler = scheduler
         self.alias = alias
         self.logger_name = f"asyncz.stores.{alias}"
         self.lock = self.create_lock()
+        scheduler_shape = getattr(scheduler, "shape", None)
+        try:
+            self.shape = resolve_shape(scheduler_shape)
+        except ShapeError:
+            self.shape = resolve_shape()
         encryption_key = os.environ.get("ASYNCZ_STORE_ENCRYPTION_KEY")
         if encryption_key:
             # we simply use a hash. This way all kinds of tokens, lengths and co are supported
@@ -55,24 +87,102 @@ class BaseStore(BaseStateExtra, StoreType):
     def shutdown(self) -> None:
         """
         Frees any resources still bound to this task store.
+
+        Subclasses remain responsible for closing backend-specific resources
+        before delegating to this shared cleanup hook.
         """
         if self.lock:
             self.lock.shutdown()
 
     def conditional_decrypt(self, inp: bytes) -> bytes:
+        """
+        Decrypt persisted store bytes when encryption is configured.
+
+        Encryption stays outside Shape payload conversion. Shapes receive and
+        return Python values, while stores own the encrypted byte boundary.
+        """
+
         if self.encryption_key:
             return self.encryption_key.decrypt(inp[:13], inp[13:], None)
         else:
             return inp
 
     def conditional_encrypt(self, inp: bytes) -> bytes:
+        """
+        Encrypt persisted store bytes when encryption is configured.
+
+        The method preserves the existing store encryption behavior and keeps
+        cryptographic decisions separate from Shape selection.
+        """
+
         if self.encryption_key:
             nonce = os.urandom(13)
             return nonce + self.encryption_key.encrypt(nonce, inp, None)
         else:
             return inp
 
+    def serialize_task_state(self, task: TaskType) -> TaskStateEnvelope:
+        """
+        Build a versioned task-state envelope for durable stores.
+
+        The task still owns its runtime state through `__getstate__()`. The
+        payload preserves that Asyncz-owned state natively so trigger objects and
+        callable references keep the same pickle behavior as legacy records.
+        """
+
+        state = task.__getstate__()
+        return TaskStateEnvelope(
+            entity=TASK_STATE_ENTITY,
+            version=TASK_STATE_ENVELOPE_VERSION,
+            shape=self.shape.name,
+            payload=state,
+        )
+
+    def deserialize_task_state(self, stored_state: Any) -> TaskState:
+        """
+        Restore a task state from a legacy record or versioned envelope.
+
+        Legacy `TaskState` pickles are accepted for backward compatibility. New
+        envelopes must declare the expected entity, version, and registered Shape
+        before restoration proceeds.
+        """
+
+        if isinstance(stored_state, TaskState):
+            return stored_state
+
+        if not isinstance(stored_state, TaskStateEnvelope):
+            raise ShapeMigrationError(
+                f"Unsupported Asyncz task state record type: {stored_state.__class__.__name__}."
+            )
+        if stored_state.entity != TASK_STATE_ENTITY:
+            raise ShapeMigrationError(
+                f"Unsupported Asyncz persisted entity: {stored_state.entity}."
+            )
+        if stored_state.version != TASK_STATE_ENVELOPE_VERSION:
+            raise ShapeMigrationError(
+                f"Unsupported Asyncz task state version: {stored_state.version}."
+            )
+
+        shape = resolve_shape(stored_state.shape)
+        context = ShapeContext(
+            entity=stored_state.entity,
+            operation="restore",
+            scheduler_identity=getattr(self.scheduler, "identity", None),
+            schema_version=stored_state.version,
+        )
+        state = shape.load(TaskState, stored_state.payload, context=context)
+        if not isinstance(state, TaskState):
+            raise ShapeDeserializationError("Task state Shape did not restore a TaskState.")
+        return state
+
     def fix_paused_tasks(self, tasks: list[TaskType]) -> None:
+        """
+        Move paused tasks behind scheduled tasks after backend sorting.
+
+        This ordering rule remains a store concern and is intentionally unrelated
+        to Shape selection or task-state serialization.
+        """
+
         for index, task in enumerate(tasks):
             if task.next_run_time is not None:
                 if index > 0:

--- a/asyncz/stores/file.py
+++ b/asyncz/stores/file.py
@@ -83,7 +83,7 @@ class FileStore(BaseStore):
         return task
 
     def rebuild_task(self, state: Any) -> TaskType:
-        state = pickle.loads(self.conditional_decrypt(state))
+        state = self.deserialize_task_state(pickle.loads(self.conditional_decrypt(state)))
         task = Task.__new__(Task)
         task.__setstate__(state)
         task.scheduler = cast("SchedulerType", self.scheduler)
@@ -142,7 +142,7 @@ class FileStore(BaseStore):
             with task_path.open("xb") as write_ob, with_lock(write_ob, LOCK_EX):
                 write_ob.write(
                     self.conditional_encrypt(
-                        pickle.dumps(task.__getstate__(), self.pickle_protocol)
+                        pickle.dumps(self.serialize_task_state(task), self.pickle_protocol)
                     )
                 )
         except FileExistsError:
@@ -156,7 +156,7 @@ class FileStore(BaseStore):
                 write_ob.truncate()
                 write_ob.write(
                     self.conditional_encrypt(
-                        pickle.dumps(task.__getstate__(), self.pickle_protocol)
+                        pickle.dumps(self.serialize_task_state(task), self.pickle_protocol)
                     )
                 )
         except FileNotFoundError:

--- a/asyncz/stores/mongo.py
+++ b/asyncz/stores/mongo.py
@@ -66,7 +66,7 @@ class MongoDBStore(BaseStore):
         return self.rebuild_task(document["state"]) if document else None
 
     def rebuild_task(self, state: Any) -> "TaskType":
-        state = pickle.loads(self.conditional_decrypt(state))
+        state = self.deserialize_task_state(pickle.loads(self.conditional_decrypt(state)))
         task = Task.__new__(Task)
         task.__setstate__(state)
         task.scheduler = cast("SchedulerType", self.scheduler)
@@ -119,7 +119,7 @@ class MongoDBStore(BaseStore):
                     "next_run_time": datetime_to_utc_timestamp(task.next_run_time or None),
                     "state": Binary(
                         self.conditional_encrypt(
-                            pickle.dumps(task.__getstate__(), self.pickle_protocol)
+                            pickle.dumps(self.serialize_task_state(task), self.pickle_protocol)
                         )
                     ),
                 }
@@ -131,7 +131,9 @@ class MongoDBStore(BaseStore):
         updates = {
             "next_run_time": datetime_to_utc_timestamp(task.next_run_time or None),
             "state": Binary(
-                self.conditional_encrypt(pickle.dumps(task.__getstate__(), self.pickle_protocol))
+                self.conditional_encrypt(
+                    pickle.dumps(self.serialize_task_state(task), self.pickle_protocol)
+                )
             ),
         }
         result = self.collection.update_one({"_id": task.id}, {"$set": updates})

--- a/asyncz/stores/persistence.py
+++ b/asyncz/stores/persistence.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+TASK_STATE_ENTITY = "task_state"
+TASK_STATE_ENVELOPE_VERSION = 1
+
+
+@dataclass(frozen=True)
+class TaskStateEnvelope:
+    """
+    Versioned persistence envelope for serialized task state.
+
+    Stores own when and where bytes are persisted. The envelope records the
+    selected Shape identity and persistence version while preserving Asyncz's
+    native task state payload for backward-compatible pickle restoration.
+    """
+
+    entity: str
+    version: int
+    shape: str
+    payload: Any

--- a/asyncz/stores/redis.py
+++ b/asyncz/stores/redis.py
@@ -58,7 +58,7 @@ class RedisStore(BaseStore):
         return self.rebuild_task(state) if state else None
 
     def rebuild_task(self, state: Any) -> "TaskType":
-        state = pickle.loads(self.conditional_decrypt(state))
+        state = self.deserialize_task_state(pickle.loads(self.conditional_decrypt(state)))
         task = Task.__new__(Task)
         task.__setstate__(state)
         task.scheduler = cast("SchedulerType", self.scheduler)
@@ -116,7 +116,9 @@ class RedisStore(BaseStore):
             pipe.hset(
                 self.tasks_key,
                 task.id,
-                self.conditional_encrypt(pickle.dumps(task.__getstate__(), self.pickle_protocol)),  # type: ignore
+                self.conditional_encrypt(
+                    pickle.dumps(self.serialize_task_state(task), self.pickle_protocol)
+                ),  # type: ignore
             )
 
             if task.next_run_time:
@@ -135,7 +137,9 @@ class RedisStore(BaseStore):
             pipe.hset(
                 self.tasks_key,
                 task.id,
-                self.conditional_encrypt(pickle.dumps(task.__getstate__(), self.pickle_protocol)),  # type: ignore
+                self.conditional_encrypt(
+                    pickle.dumps(self.serialize_task_state(task), self.pickle_protocol)
+                ),  # type: ignore
             )
             if task.next_run_time:
                 pipe.zadd(

--- a/asyncz/stores/sqlalchemy.py
+++ b/asyncz/stores/sqlalchemy.py
@@ -72,7 +72,7 @@ class SQLAlchemyStore(BaseStore):
         return tasks[0] if tasks else None
 
     def rebuild_task(self, state: Any) -> TaskType:
-        state = pickle.loads(self.conditional_decrypt(state))
+        state = self.deserialize_task_state(pickle.loads(self.conditional_decrypt(state)))
         task = Task.__new__(Task)
         task.__setstate__(state)
         task.scheduler = cast("SchedulerType", self.scheduler)
@@ -130,7 +130,7 @@ class SQLAlchemyStore(BaseStore):
             "id": task.id,
             "next_run_time": datetime_to_utc_timestamp(task.next_run_time or None),
             "state": self.conditional_encrypt(
-                pickle.dumps(task.__getstate__(), self.pickle_protocol)
+                pickle.dumps(self.serialize_task_state(task), self.pickle_protocol)
             ),
         }
         try:
@@ -143,7 +143,7 @@ class SQLAlchemyStore(BaseStore):
         updates = {
             "next_run_time": datetime_to_utc_timestamp(task.next_run_time or None),
             "state": self.conditional_encrypt(
-                pickle.dumps(task.__getstate__(), self.pickle_protocol)
+                pickle.dumps(self.serialize_task_state(task), self.pickle_protocol)
             ),
         }
         success = True

--- a/docs/en/docs/index.md
+++ b/docs/en/docs/index.md
@@ -96,6 +96,7 @@ asyncz run cleanup-task --store durable=sqlite:///scheduler.db
 - [Schedulers](./schedulers.md) for configuration, lifecycle, and logging.
 - [Triggers](./triggers.md) for scheduling rules.
 - [Tasks](./tasks.md) for task objects, decorator mode, and lifecycle generators.
+- [Shapes](./shapes.md) for validator-agnostic scheduler representation.
 - [Stores](./stores.md) for persistence and encryption.
 - [Executors](./executors.md) for runtime execution strategy.
 - [ASGI and Context Managers](./asgi.md) for framework integration.

--- a/docs/en/docs/release-notes.md
+++ b/docs/en/docs/release-notes.md
@@ -1,5 +1,31 @@
 # Release Notes
 
+## 0.17.0
+
+### Highlights
+
+- Asyncz now has Shapes: a validator-agnostic representation layer that keeps
+  scheduler behavior owned by Asyncz while preserving Pydantic as the default.
+- Schedulers can be configured with built-in or custom Shapes by instance, class,
+  or registered name.
+- Durable task records now include a versioned persistence envelope with Shape
+  identity while continuing to restore existing raw task-state records.
+
+### Added
+
+- Public `asyncz.shapes` APIs for Shape implementations, registry operations,
+  capability errors, dependency errors, and migration-safe restoration failures.
+- Built-in Pydantic, dataclass, attrs, msgspec, and trusted Python Shapes.
+- `from asyncz import Asyncz` as the default `AsyncIOScheduler` entry point.
+- Documentation for adopting, extending, testing, and operating Shapes.
+
+### Compatibility
+
+- Existing Pydantic-first usage remains the default.
+- Legacy durable task records continue to restore.
+- Optional attrs and msgspec support is available through `asyncz[attrs]`,
+  `asyncz[msgspec]`, or `asyncz[all-shapes]`.
+
 ## 0.16.0
 
 ### Highlights

--- a/docs/en/docs/shapes.md
+++ b/docs/en/docs/shapes.md
@@ -1,0 +1,376 @@
+# Asyncz Shapes
+
+Asyncz Shapes make scheduler-facing representation validator-agnostic without
+moving scheduler behavior into a validation library.
+
+A Shape owns representation mechanics:
+
+- validation and construction of scheduler-facing values;
+- dumping values for configuration, diagnostics, or persistence boundaries;
+- restoring values from stored representations;
+- field inspection where the underlying library supports it;
+- optional schema generation;
+- translation of library-specific errors into Asyncz Shape errors.
+
+A Shape does not own scheduling semantics. Triggers still calculate run times,
+stores still own persistence and locking, executors still run tasks, and the
+scheduler still owns lifecycle, misfire handling, coalescing, task acquisition,
+events, and state transitions.
+
+Pydantic remains the default Shape so existing installations continue to feel
+familiar:
+
+```python
+from asyncz import Asyncz
+
+scheduler = Asyncz()
+```
+
+You can select a Shape explicitly:
+
+```python
+from asyncz import Asyncz
+from asyncz.shapes import DataclassShape
+
+scheduler = Asyncz(shape=DataclassShape())
+```
+
+Or by registered name:
+
+```python
+from asyncz import Asyncz
+
+scheduler = Asyncz(shape="dataclass")
+```
+
+## Built-in Shapes
+
+| Shape | Name | Dependency | Notes |
+| ----- | ---- | ---------- | ----- |
+| `PydanticShape` | `pydantic` | default install | Default behavior and best compatibility with existing Asyncz usage |
+| `DataclassShape` | `dataclass` | standard library | Construction and field inspection for dataclasses; no Pydantic-equivalent runtime validation |
+| `AttrsShape` | `attrs` | `asyncz[attrs]` | Uses public attrs APIs, validators, converters, factories, and field metadata |
+| `MsgspecShape` | `msgspec` | `asyncz[msgspec]` | Uses msgspec conversion, builtins dumping, Struct fields, and JSON schema support |
+| `AnyShape` | `any` | default install | Opt-in permissive mode for trusted values with weak validation and no schema support |
+
+Install optional Shapes with:
+
+```bash
+pip install "asyncz[attrs]"
+pip install "asyncz[msgspec]"
+pip install "asyncz[all-shapes]"
+```
+
+Selecting a Shape whose dependency is missing raises `ShapeDependencyError` with
+the exact extra to install. Asyncz does not silently fall back to Pydantic or
+`AnyShape`.
+
+## Quick Start
+
+Default Pydantic behavior needs no configuration:
+
+```python
+from asyncz import Asyncz
+
+scheduler = Asyncz()
+```
+
+Dataclass-backed configuration:
+
+```python
+from dataclasses import dataclass
+
+from asyncz import Asyncz
+
+
+@dataclass
+class TaskDefaults:
+    mistrigger_grace_time: float = 5
+    coalesce: bool = False
+    max_instances: int = 3
+
+
+scheduler = Asyncz(shape="dataclass", task_defaults=TaskDefaults())
+```
+
+Attrs-backed configuration:
+
+```python
+import attr
+
+from asyncz import Asyncz
+
+
+@attr.define
+class TaskDefaults:
+    mistrigger_grace_time: float = 5
+    coalesce: bool = False
+    max_instances: int = 3
+
+
+scheduler = Asyncz(shape="attrs", task_defaults=TaskDefaults())
+```
+
+Msgspec-backed configuration:
+
+```python
+import msgspec
+
+from asyncz import Asyncz
+
+
+class TaskDefaults(msgspec.Struct):
+    mistrigger_grace_time: float = 5
+    coalesce: bool = False
+    max_instances: int = 3
+
+
+scheduler = Asyncz(shape="msgspec", task_defaults=TaskDefaults())
+```
+
+Permissive trusted configuration:
+
+```python
+from asyncz import Asyncz
+
+scheduler = Asyncz(shape="any", task_defaults={"max_instances": "4"})
+```
+
+Check the active Shape:
+
+```python
+assert scheduler.shape.name == "pydantic"
+```
+
+## Registry
+
+`ShapeRegistry` is the canonical registry owner. It supports deterministic
+registration, lookup, duplicate rejection, replacement, unregistering, and
+introspection:
+
+```python
+from asyncz.shapes import AnyShape, ShapeRegistry
+
+
+class CompanyShape(AnyShape):
+    """
+    Company-specific Shape for trusted internal scheduler configuration.
+
+    Production implementations usually override construction, dumping, loading,
+    and error translation instead of inheriting all permissive behavior.
+    """
+
+    name = "company"
+
+
+ShapeRegistry.register("company", CompanyShape)
+assert ShapeRegistry.available()
+
+scheduler = Asyncz(shape="company")
+```
+
+You can also use the decorator helper:
+
+```python
+from asyncz.shapes import Shape, register_shape
+
+
+@register_shape("company")
+class CompanyShape(Shape):
+    """
+    Company-specific Shape registered during application startup.
+
+    The decorated class is returned unchanged, so tests and subclasses can use
+    it normally after registration.
+    """
+```
+
+Duplicate names fail unless `replace=True` is explicit. This prevents import
+order from changing Shape resolution.
+
+## Custom Shape Contract
+
+Subclass `Shape` and implement only the capabilities your application needs.
+
+```python
+from collections.abc import Mapping
+from typing import Any
+
+from asyncz.shapes import (
+    Shape,
+    ShapeCapabilityError,
+    ShapeContext,
+    ShapeField,
+    ShapeRegistry,
+    ShapeValidationError,
+)
+
+
+class CompanyShape(Shape):
+    """
+    Example custom Shape using ordinary Python model classes.
+
+    It validates mapping inputs, constructs model instances, dumps public
+    attributes, and reports field metadata for classes that declare
+    `__annotations__`.
+    """
+
+    name = "company"
+
+    def supports(self, value_or_type: Any) -> bool:
+        """
+        Return whether the object follows the company model convention.
+
+        The convention here is deliberately small: supported classes declare a
+        `__company_shape__` marker attribute.
+        """
+
+        candidate = value_or_type if isinstance(value_or_type, type) else type(value_or_type)
+        return bool(getattr(candidate, "__company_shape__", False))
+
+    def construct(
+        self, model_type: type[Any], values: Any, *, context: ShapeContext | None = None
+    ) -> Any:
+        """
+        Build a company model from a mapping or return an existing instance.
+
+        Real implementations can add stricter validation, nested conversion,
+        and application-specific error messages here.
+        """
+
+        if isinstance(values, model_type):
+            return values
+        if not isinstance(values, Mapping):
+            raise ShapeValidationError("CompanyShape expects a mapping.")
+        try:
+            return model_type(**values)
+        except Exception as exc:
+            raise ShapeValidationError("CompanyShape could not construct the model.") from exc
+
+    def dump(
+        self,
+        value: Any,
+        *,
+        mode: str | None = None,
+        context: ShapeContext | None = None,
+        exclude_none: bool = False,
+    ) -> dict[str, Any]:
+        """
+        Dump public attributes from a company model.
+
+        Private attributes are not included, and `None` values can be removed
+        when Asyncz asks for a compact representation.
+        """
+
+        data = {
+            key: item
+            for key, item in vars(value).items()
+            if not key.startswith("_")
+        }
+        if exclude_none:
+            return {key: item for key, item in data.items() if item is not None}
+        return data
+
+    def fields(
+        self, model_type: type[Any], *, context: ShapeContext | None = None
+    ) -> tuple[ShapeField, ...]:
+        """
+        Return field metadata for annotated company models.
+
+        Classes without annotations do not have enough metadata for stable field
+        inspection, so they fail with an explicit capability error.
+        """
+
+        annotations = getattr(model_type, "__annotations__", None)
+        if not annotations:
+            raise ShapeCapabilityError("CompanyShape requires annotations for fields.")
+        return tuple(
+            ShapeField(name=name, annotation=annotation)
+            for name, annotation in annotations.items()
+        )
+
+
+ShapeRegistry.register("company", CompanyShape)
+```
+
+Custom Shapes should be stateless or safe to share across scheduler operations.
+When a Shape wraps a third-party library, raise Asyncz Shape errors and keep the
+original exception as the cause:
+
+```python
+raise ShapeValidationError("Could not validate company task defaults.") from exc
+```
+
+## Persistence
+
+Durable stores persist a versioned task-state envelope. The envelope records:
+
+- entity kind, currently `task_state`;
+- representation version;
+- selected Shape name;
+- Asyncz's native task-state payload.
+
+Existing raw `TaskState` pickle records are still accepted for compatibility.
+New records include Shape metadata so future migrations can fail clearly instead
+of guessing which representation wrote a record.
+
+Store encryption remains a store concern. If `ASYNCZ_STORE_ENCRYPTION_KEY` is
+set, the serialized envelope bytes are encrypted after the Shape boundary.
+
+Unknown Shape names and unsupported envelope versions fail explicitly. Asyncz
+does not import arbitrary application model paths from persisted records.
+
+## Migration Notes
+
+Existing users can keep constructing schedulers exactly as before. Pydantic is
+still installed by default and remains the default Shape.
+
+Compatibility preserved in this release:
+
+- `AsyncIOScheduler()` and `NativeAsyncIOScheduler()` default behavior;
+- Pydantic-style `task_defaults.model_dump()` for existing callers;
+- legacy raw `TaskState` records in durable stores;
+- existing task, trigger, executor, event, CLI, and dashboard scheduling behavior.
+
+New behavior:
+
+- `from asyncz import Asyncz` is an alias for `AsyncIOScheduler`;
+- schedulers accept `shape=...`;
+- built-in Shape names can be resolved through `ShapeRegistry`;
+- new durable task records include a versioned Shape envelope.
+
+Do not use `AnyShape` for untrusted input. It is intentionally permissive and
+pushes validation responsibility to application code.
+
+## Error Handling
+
+Shape errors live in `asyncz.shapes`:
+
+- `ShapeNotFoundError`
+- `ShapeRegistrationError`
+- `ShapeCapabilityError`
+- `ShapeValidationError`
+- `ShapeSerializationError`
+- `ShapeDeserializationError`
+- `ShapeCompatibilityError`
+- `ShapeDependencyError`
+- `ShapeMigrationError`
+
+Each error identifies the representation boundary that failed. Third-party
+validator exceptions are kept as causes where they contain useful detail.
+
+## Testing Shapes
+
+Application Shape tests should cover:
+
+- construction from mappings and existing instances;
+- invalid values and nested error paths;
+- dump and load round trips;
+- field inspection and schema capabilities;
+- missing optional dependencies;
+- durable store restart when the Shape is used by a scheduler;
+- unknown Shape and incompatible version failures.
+
+For scheduler behavior, assert outcomes rather than validator internals. Adding
+or changing one Shape should not require branching in scheduler, trigger, store,
+executor, or event logic.

--- a/docs/en/docs/stores.md
+++ b/docs/en/docs/stores.md
@@ -18,6 +18,19 @@ All built-in stores except `MemoryStore` support `ASYNCZ_STORE_ENCRYPTION_KEY`.
 
 When it is set, Asyncz encrypts serialized task payloads before they are written to the store. This is strongly recommended for any store that can be modified by untrusted users or processes.
 
+## Persistence envelopes
+
+Durable stores write a versioned task-state envelope around new task records.
+The envelope records the Asyncz entity kind, persistence version, selected
+Shape name, and native task-state payload.
+
+Older raw `TaskState` pickle records still restore. Unknown Shape names or
+unsupported envelope versions fail clearly instead of being interpreted through
+another representation.
+
+Shapes do not own store locking, encryption, task acquisition, or backend
+queries. Those remain store responsibilities.
+
 ## `MemoryStore`
 
 The default store. It is fast and simple, but it does not survive process restarts.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -71,6 +71,7 @@ nav:
   - schedulers.md
   - triggers.md
   - tasks.md
+  - shapes.md
   - executors.md
   - stores.md
   - events.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ asyncz = "asyncz.cli.app:main"
 
 [project.optional-dependencies]
 localtime=["tzlocal"]
+attrs = ["attrs>=23.1.0"]
+msgspec = ["msgspec>=0.18.0"]
+all-shapes = ["attrs>=23.1.0", "msgspec>=0.18.0"]
 testing = [
     "asyncz[localtime]",
     "pymongo>=4.3.3,<5.0.0",

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -20,12 +20,26 @@ from asyncz.shapes import (
 
 @dataclass
 class DataclassDefaults:
+    """
+    Test-only dataclass that mirrors scheduler task default configuration.
+
+    It proves the scheduler can accept a non-Pydantic configuration object
+    through the same Shape resolution path used by production code.
+    """
+
     mistrigger_grace_time: float = 7
     coalesce: bool = False
     max_instances: int = 3
 
 
 def test_top_level_asyncz_alias_uses_default_pydantic_shape():
+    """
+    Confirm the top-level `Asyncz` alias keeps the default Pydantic experience.
+
+    The ordinary constructor should require no Shape configuration and should
+    still expose task defaults through the compatibility `model_dump()` surface.
+    """
+
     scheduler = Asyncz()
 
     assert isinstance(scheduler, AsyncIOScheduler)
@@ -38,6 +52,13 @@ def test_top_level_asyncz_alias_uses_default_pydantic_shape():
 
 
 def test_scheduler_accepts_registered_shape_name_for_configuration():
+    """
+    Verify scheduler configuration can select a registered Shape by name.
+
+    The dataclass defaults object exercises a non-Pydantic representation while
+    still normalizing into Asyncz-owned task defaults.
+    """
+
     scheduler = AsyncIOScheduler(shape="dataclass", task_defaults=DataclassDefaults())
 
     assert isinstance(scheduler.shape, DataclassShape)
@@ -49,6 +70,13 @@ def test_scheduler_accepts_registered_shape_name_for_configuration():
 
 
 def test_scheduler_accepts_shape_instance():
+    """
+    Verify scheduler configuration accepts an already-instantiated Shape.
+
+    This covers applications that want to configure Shape instances explicitly
+    instead of relying on global registry lookup.
+    """
+
     shape = AnyShape()
     scheduler = AsyncIOScheduler(shape=shape, task_defaults={"max_instances": "4"})
 
@@ -61,7 +89,21 @@ def test_scheduler_accepts_shape_instance():
 
 
 def test_shape_registry_is_deterministic_and_rejects_duplicates():
+    """
+    Prove registry lookup is deterministic and duplicate names fail clearly.
+
+    A custom test Shape is registered temporarily to ensure the public registry
+    path works without relying on internal imports.
+    """
+
     class CompanyShape(AnyShape):
+        """
+        Test-only custom Shape used to exercise public registry behavior.
+
+        It inherits permissive behavior because this test is about registry
+        ownership rather than validation semantics.
+        """
+
         name = "company"
 
     ShapeRegistry.register("company-test", CompanyShape)
@@ -75,11 +117,25 @@ def test_shape_registry_is_deterministic_and_rejects_duplicates():
 
 
 def test_shape_registry_reports_unknown_shapes():
+    """
+    Verify unknown Shape names fail instead of falling back silently.
+
+    This protects scheduler configuration and persisted records from changing
+    validator behavior because of missing registrations.
+    """
+
     with pytest.raises(ShapeNotFoundError):
         ShapeRegistry.get("does-not-exist")
 
 
 def test_dataclass_shape_contract_round_trip():
+    """
+    Exercise the dataclass Shape contract directly.
+
+    The test covers construction, dumping, and field inspection so dataclasses
+    prove the first non-Pydantic contract path without scheduler branching.
+    """
+
     shape = DataclassShape()
     context = ShapeContext(entity="task_defaults", operation="round_trip")
     defaults = shape.construct(

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from asyncz import Asyncz
+from asyncz.schedulers import AsyncIOScheduler
+from asyncz.shapes import (
+    AnyShape,
+    DataclassShape,
+    PydanticShape,
+    ShapeContext,
+    ShapeNotFoundError,
+    ShapeRegistrationError,
+    ShapeRegistry,
+    shapes,
+)
+
+
+@dataclass
+class DataclassDefaults:
+    mistrigger_grace_time: float = 7
+    coalesce: bool = False
+    max_instances: int = 3
+
+
+def test_top_level_asyncz_alias_uses_default_pydantic_shape():
+    scheduler = Asyncz()
+
+    assert isinstance(scheduler, AsyncIOScheduler)
+    assert isinstance(scheduler.shape, PydanticShape)
+    assert scheduler.task_defaults.model_dump() == {
+        "mistrigger_grace_time": 1.0,
+        "coalesce": True,
+        "max_instances": 1,
+    }
+
+
+def test_scheduler_accepts_registered_shape_name_for_configuration():
+    scheduler = AsyncIOScheduler(shape="dataclass", task_defaults=DataclassDefaults())
+
+    assert isinstance(scheduler.shape, DataclassShape)
+    assert scheduler.task_defaults.model_dump() == {
+        "mistrigger_grace_time": 7.0,
+        "coalesce": False,
+        "max_instances": 3,
+    }
+
+
+def test_scheduler_accepts_shape_instance():
+    shape = AnyShape()
+    scheduler = AsyncIOScheduler(shape=shape, task_defaults={"max_instances": "4"})
+
+    assert scheduler.shape is shape
+    assert scheduler.task_defaults.model_dump() == {
+        "mistrigger_grace_time": 1.0,
+        "coalesce": True,
+        "max_instances": 4,
+    }
+
+
+def test_shape_registry_is_deterministic_and_rejects_duplicates():
+    class CompanyShape(AnyShape):
+        name = "company"
+
+    ShapeRegistry.register("company-test", CompanyShape)
+    try:
+        assert isinstance(shapes.get("company-test"), CompanyShape)
+        assert "company-test" in shapes.available()
+        with pytest.raises(ShapeRegistrationError):
+            ShapeRegistry.register("company-test", CompanyShape)
+    finally:
+        ShapeRegistry.unregister("company-test")
+
+
+def test_shape_registry_reports_unknown_shapes():
+    with pytest.raises(ShapeNotFoundError):
+        ShapeRegistry.get("does-not-exist")
+
+
+def test_dataclass_shape_contract_round_trip():
+    shape = DataclassShape()
+    context = ShapeContext(entity="task_defaults", operation="round_trip")
+    defaults = shape.construct(
+        DataclassDefaults,
+        {"mistrigger_grace_time": 2, "coalesce": False, "max_instances": 5},
+        context=context,
+    )
+
+    assert defaults == DataclassDefaults(2, False, 5)
+    assert shape.dump(defaults, context=context) == {
+        "mistrigger_grace_time": 2,
+        "coalesce": False,
+        "max_instances": 5,
+    }
+    assert [field.name for field in shape.fields(DataclassDefaults)] == [
+        "mistrigger_grace_time",
+        "coalesce",
+        "max_instances",
+    ]

--- a/tests/test_stores.py
+++ b/tests/test_stores.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 import tempfile
 import time
 from datetime import datetime
@@ -8,8 +9,14 @@ from sqlalchemy.pool import StaticPool
 
 from asyncz.exceptions import ConflictIdError, TaskLookupError
 from asyncz.schedulers import AsyncIOScheduler
+from asyncz.shapes import ShapeMigrationError, ShapeNotFoundError
 from asyncz.stores.file import FileStore
 from asyncz.stores.memory import MemoryStore
+from asyncz.stores.persistence import (
+    TASK_STATE_ENTITY,
+    TASK_STATE_ENVELOPE_VERSION,
+    TaskStateEnvelope,
+)
 from asyncz.tasks import Task
 
 
@@ -136,6 +143,90 @@ def test_add_callable_instance_method_task(store, create_add_task):
     initial_task = create_add_task(store, instance.dummy_method, kwargs={"a": 1, "b": 2})
     task = store.lookup_task(initial_task.id)
     assert task.fn(*task.args, **task.kwargs) == 3
+
+
+def test_persistent_store_writes_shape_envelope(filestore, create_add_task):
+    """
+    Verify durable stores write explicit Shape metadata for new task records.
+
+    The file store is used as the concrete persistent backend because its bytes
+    are easy to inspect without involving an external service.
+    """
+
+    task = create_add_task(filestore)
+    task_path = filestore.directory / f"{task.id}{filestore.suffix}"
+
+    envelope = pickle.loads(filestore.conditional_decrypt(task_path.read_bytes()))
+
+    assert isinstance(envelope, TaskStateEnvelope)
+    assert envelope.entity == TASK_STATE_ENTITY
+    assert envelope.version == TASK_STATE_ENVELOPE_VERSION
+    assert envelope.shape == "pydantic"
+    assert envelope.payload.id == task.id
+
+
+def test_persistent_store_restores_legacy_task_state(filestore, create_add_task):
+    """
+    Verify old raw `TaskState` pickles still restore correctly.
+
+    This is the compatibility path for records written before Asyncz introduced
+    versioned Shape persistence envelopes.
+    """
+
+    task = create_add_task(None)
+    task_path = filestore.directory / f"{task.id}{filestore.suffix}"
+    task_path.write_bytes(
+        filestore.conditional_encrypt(pickle.dumps(task.__getstate__(), filestore.pickle_protocol))
+    )
+
+    restored = filestore.lookup_task(task.id)
+
+    assert restored == task
+    assert restored.fn is dummy_task
+
+
+def test_persistent_store_rejects_unknown_shape(filestore, create_add_task):
+    """
+    Verify persisted records with unknown Shape identifiers fail clearly.
+
+    Stores must not fall back to another Shape when a record names a missing
+    validator representation.
+    """
+
+    task = create_add_task(None)
+    envelope = TaskStateEnvelope(
+        entity=TASK_STATE_ENTITY,
+        version=TASK_STATE_ENVELOPE_VERSION,
+        shape="missing-shape",
+        payload=task.__getstate__(),
+    )
+
+    with pytest.raises(ShapeNotFoundError):
+        filestore.rebuild_task(
+            filestore.conditional_encrypt(pickle.dumps(envelope, filestore.pickle_protocol))
+        )
+
+
+def test_persistent_store_rejects_unknown_version(filestore, create_add_task):
+    """
+    Verify future task-state envelope versions are rejected explicitly.
+
+    This keeps migration behavior deliberate instead of attempting to interpret
+    records from an unknown persistence contract.
+    """
+
+    task = create_add_task(None)
+    envelope = TaskStateEnvelope(
+        entity=TASK_STATE_ENTITY,
+        version=TASK_STATE_ENVELOPE_VERSION + 1,
+        shape="pydantic",
+        payload=task.__getstate__(),
+    )
+
+    with pytest.raises(ShapeMigrationError):
+        filestore.rebuild_task(
+            filestore.conditional_encrypt(pickle.dumps(envelope, filestore.pickle_protocol))
+        )
 
 
 def test_add_callable_class_method_task(store, create_add_task):


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Asyncz Shapes, a validator-agnostic representation layer, with Pydantic as the default. Durable stores now write versioned task-state envelopes that include the Shape; legacy records still restore.

- New Features
  - Shapes contract with built-ins: `pydantic`, `dataclass`, `attrs`, `msgspec`, and `any`; select via scheduler `shape` (name, class, or instance) and a public registry.
  - Stores persist a `task_state` envelope (versioned, includes Shape name); encryption unchanged; old raw `TaskState` pickles remain supported.
  - Scheduler uses the active Shape to dump `task_defaults` and task updates; `TaskDefaultStruct` is now scheduler-owned with `model_dump()` compatibility.
  - Top-level `from asyncz import Asyncz` alias for the default `AsyncIOScheduler`.

- Migration
  - No changes needed for existing users; default stays `pydantic`.
  - Optional Shapes: pip install `asyncz[attrs]`, `asyncz[msgspec]`, or `asyncz[all-shapes]`.
  - New records include Shape/version; unknown Shapes or future versions fail clearly instead of falling back.

<sup>Written for commit a57685a929c41dcd6fda163741a77f2ea47c282a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dymmond/asyncz/pull/126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

